### PR TITLE
Upgrade carbon.automation version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -624,7 +624,7 @@
         <carbon.analytics.common.version>5.1.7</carbon.analytics.common.version>
         <siddhi.version>3.1.2</siddhi.version>
         <carbon.automationutils.version>4.4.1</carbon.automationutils.version>
-        <carbon.automation.version>4.4.2</carbon.automation.version>
+        <carbon.automation.version>4.4.3</carbon.automation.version>
         <carbon.registry.version>4.6.0</carbon.registry.version>
         <carbon.multitenancy.version>4.6.0</carbon.multitenancy.version>
         <carbon.deployment.version>4.7.0</carbon.deployment.version>
@@ -651,7 +651,7 @@
         <orbit.version.h2>1.2.140.wso2v3</orbit.version.h2>
         <orbit.version.ua_parser>1.3.0.wso2v1</orbit.version.ua_parser>
 
-        <jacoco.agent.version>0.7.4.201502262128</jacoco.agent.version>
+        <jacoco.agent.version>0.7.5.201505241946</jacoco.agent.version>
         <testng.version>6.1.1</testng.version>
         <junit.version>4.10</junit.version>
 


### PR DESCRIPTION
## Purpose
Get line coverage information to the jacoco plugin in jenkins server

## Goals
Upgrade carbon.automation version and jacoco version to match the jacoco version in jenkins