### PR TITLE
Fix APIM_ALERT_STAKEHOLDER stream

### DIFF
--- a/modules/distribution/carbon-home/deployment/siddhi-files/APIM_ALERT_STAKEHOLDER.siddhi
+++ b/modules/distribution/carbon-home/deployment/siddhi-files/APIM_ALERT_STAKEHOLDER.siddhi
@@ -1,7 +1,7 @@
 @App:name('APIM_ALERT_STAKEHOLDER')
 @App:description('Store the alert subscribers information in the database')
 
---@source(type = 'wso2event', wso2.stream.id = 'org.wso2.analytics.apim.alertStakeholderInfo:1.0.0', @map(type = 'wso2event'))
+@source(type = 'wso2event', wso2.stream.id = 'org.wso2.analytics.apim.alertStakeholderInfo:1.0.1', @map(type = 'wso2event'))
 define stream AlertStakeholderInfoStream (
     userId	string,
     alertTypes	string,


### PR DESCRIPTION
## Purpose
Previous version was on 1.0.1 and new version was set to 1.0.0. This was corrected and unintentionally commented stream definition is uncommented.