### PR TITLE
Copy widgets to dashboard runtime

### DIFF
--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -242,6 +242,14 @@
             <outputDirectory>wso2/dashboard/deployment/web-ui-apps/policies</outputDirectory>
             <fileMode>644</fileMode>
         </fileSet>
+        <fileSet>
+            <directory>carbon-home/deployment/widgets/</directory>
+            <outputDirectory>wso2/dashboard/deployment/web-ui-apps/portal/extensions/widgets</outputDirectory>
+            <excludes>
+                <exclude>**/src/</exclude>
+            </excludes>
+            <fileMode>644</fileMode>
+        </fileSet>
     </fileSets>
     <files>
         <file>


### PR DESCRIPTION
## Purpose
Copy widget files from src to dashboard profiles's extensions directory at build time

## Documentation
No impact

