### PR TITLE
Streamlining of default configuration

### DIFF
--- a/modules/distribution/carbon-home/conf/dashboard/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/dashboard/deployment.yaml
@@ -399,3 +399,4 @@ auth.configs:
          role:
            id: 1
            displayName: admin
+           

--- a/modules/distribution/carbon-home/conf/dashboard/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/dashboard/deployment.yaml
@@ -381,3 +381,21 @@ wso2.transport.http:
       keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
       keyStorePassword: wso2carbon
       certPass: wso2carbon
+
+# Authentication configuration
+auth.configs:
+  type: 'local'        # Type of the IdP client used
+  userManager:
+    adminRole: admin   # Admin role which is granted all permissions
+    userStore:         # User store
+      users:
+       -
+         user:
+           username: admin
+           password: YWRtaW4=
+           roles: 1
+      roles:
+       -
+         role:
+           id: 1
+           displayName: admin

--- a/modules/distribution/carbon-home/conf/manager/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/manager/deployment.yaml
@@ -312,3 +312,4 @@ auth.configs:
          role:
            id: 1
            displayName: admin
+

--- a/modules/distribution/carbon-home/conf/manager/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/manager/deployment.yaml
@@ -294,3 +294,21 @@ deployment.config:
     zooKeeperURLs: localhost:2181   # zookeeper urls
     connectionTimeout: 10000
     sessionTimeout: 10000
+
+# Authentication configuration
+auth.configs:
+  type: 'local'        # Type of the IdP client used
+  userManager:
+    adminRole: admin   # Admin role which is granted all permissions
+    userStore:         # User store
+      users:
+       -
+         user:
+           username: admin
+           password: YWRtaW4=
+           roles: 1
+      roles:
+       -
+         role:
+           id: 1
+           displayName: admin

--- a/modules/distribution/carbon-home/conf/worker/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/worker/deployment.yaml
@@ -322,22 +322,6 @@ wso2.securevault:
   # Datasource Configurations
 wso2.datasources:
   dataSources:
-    -
-      definition:
-        configuration:
-          connectionTestQuery: "SELECT 1"
-          driverClassName: org.h2.Driver
-          idleTimeout: 60000
-          isAutoCommit: false
-          jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
-          maxPoolSize: 10
-          password: wso2carbon
-          username: wso2carbon
-          validationTimeout: 30000
-        type: RDBMS
-      description: "The datasource used for registry and user manager"
-      name: WSO2_CARBON_DB
-
     # carbon metrics data source
     - name: WSO2_METRICS_DB
       description: The datasource used for dashboard feature
@@ -369,23 +353,6 @@ wso2.datasources:
           password: wso2carbon
           driverClassName: org.h2.Driver
           maxPoolSize: 10
-          idleTimeout: 60000
-          connectionTestQuery: SELECT 1
-          validationTimeout: 30000
-          isAutoCommit: false
-
-    - name: Message_Tracing_DB
-      description: "The datasource used for message tracer to store span information."
-      jndiConfig:
-        name: jdbc/Message_Tracing_DB
-      definition:
-        type: RDBMS
-        configuration:
-          jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/dashboard/database/MESSAGE_TRACING_DB;AUTO_SERVER=TRUE'
-          username: wso2carbon
-          password: wso2carbon
-          driverClassName: org.h2.Driver
-          maxPoolSize: 30
           idleTimeout: 60000
           connectionTestQuery: SELECT 1
           validationTimeout: 30000
@@ -440,6 +407,21 @@ wso2.datasources:
           connectionTestQuery: SELECT 1
           validationTimeout: 30000
           isAutoCommit: false
+#    -
+#      name: WSO2_CLUSTER_DB
+#      description: "The datasource used by cluster coordinators in HA deployment"
+#      definition:
+#        type: RDBMS
+#        configuration:
+#          connectionTestQuery: "SELECT 1"
+#          driverClassName: org.h2.Driver
+#          idleTimeout: 60000
+#          isAutoCommit: false
+#          jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CLUSTER_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE"
+#          maxPoolSize: 10
+#          password: wso2carbon
+#          username: wso2carbon
+#          validationTimeout: 30000
 
 siddhi:
   extensions:
@@ -470,7 +452,7 @@ cluster.config:
   groupId:  sp
   coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
   strategyConfig:
-    datasource: WSO2_CARBON_DB
+    datasource: WSO2_CLUSTER_DB
     heartbeatInterval: 1000
     heartbeatMaxRetry: 2
     eventPollingInterval: 1000

--- a/modules/distribution/carbon-home/conf/worker/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/worker/deployment.yaml
@@ -407,21 +407,21 @@ wso2.datasources:
           connectionTestQuery: SELECT 1
           validationTimeout: 30000
           isAutoCommit: false
-#    -
-#      name: WSO2_CLUSTER_DB
-#      description: "The datasource used by cluster coordinators in HA deployment"
-#      definition:
-#        type: RDBMS
-#        configuration:
-#          connectionTestQuery: "SELECT 1"
-#          driverClassName: org.h2.Driver
-#          idleTimeout: 60000
-#          isAutoCommit: false
-#          jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CLUSTER_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE"
-#          maxPoolSize: 10
-#          password: wso2carbon
-#          username: wso2carbon
-#          validationTimeout: 30000
+    -
+      name: WSO2_CLUSTER_DB
+      description: "The datasource used by cluster coordinators in HA deployment"
+      definition:
+        type: RDBMS
+        configuration:
+          connectionTestQuery: "SELECT 1"
+          driverClassName: org.h2.Driver
+          idleTimeout: 60000
+          isAutoCommit: false
+          jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CLUSTER_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE"
+          maxPoolSize: 10
+          password: wso2carbon
+          username: wso2carbon
+          validationTimeout: 30000
 
 siddhi:
   extensions:

--- a/modules/distribution/carbon-home/conf/worker/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/worker/deployment.yaml
@@ -457,6 +457,25 @@ cluster.config:
     heartbeatMaxRetry: 2
     eventPollingInterval: 1000
 
+# Authentication configuration
+auth.configs:
+  type: 'local'        # Type of the IdP client used
+  userManager:
+    adminRole: admin   # Admin role which is granted all permissions
+    userStore:         # User store
+      users:
+       -
+         user:
+           username: admin
+           password: YWRtaW4=
+           roles: 1
+      roles:
+       -
+         role:
+           id: 1
+           displayName: admin
+
+
   # Sample of deployment.config for Two node HA
 #deployment.config:
 #  type: ha


### PR DESCRIPTION
## Purpose
Clean up of default configs to remove user confusion
1. Add authentication configs by default
2. Rename WSO2_CARBON_DB used in HA deployment as WSO2_CLUSTER_DB. 

## Documentation
Rename of WSO2_CARBON_DB needs to be documented. Please note this DB is only used in HA deployments

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes