### PR TITLE
Add support for Java 11 and other improvements

### DIFF
--- a/features/org.wso2.analytics.apim.rest.api.config.feature/pom.xml
+++ b/features/org.wso2.analytics.apim.rest.api.config.feature/pom.xml
@@ -26,7 +26,7 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <propertyFile>../org.wso2.analytics.apim.idp.client.feature/etc/feature.properties</propertyFile>
+                            <propertyFile>../org.wso2.analytics.apim.rest.api.config.feature/etc/feature.properties</propertyFile>
                             <adviceFileContents>
                                 <advice>
                                     <name>org.wso2.carbon.p2.category.type</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1371,6 +1371,7 @@
         <siddhi.map.text.version>2.0.2</siddhi.map.text.version>
         <siddhi.map.wso2event.version>5.0.1</siddhi.map.wso2event.version>
         <siddhi.store.rdbms.version>6.0.3</siddhi.store.rdbms.version>
+        <siddhi.io.grpc.version>1.0.3</siddhi.io.grpc.version>
         <carbon.coordination.version>2.1.1</carbon.coordination.version>
 
         <!--Apim Analytics Idp client related -->

--- a/pom.xml
+++ b/pom.xml
@@ -1384,7 +1384,7 @@
 
         <!--Apim Analytics Idp client related -->
         <feign.version>9.5.0</feign.version>
-        <org.apache.axis2.wso2.version>1.6.1-wso2v37</org.apache.axis2.wso2.version>
+        <org.apache.axis2.wso2.version>1.6.1-wso2v38</org.apache.axis2.wso2.version>
         <org.apache.ws.commons.axiom.wso2.version>1.2.11-wso2v16</org.apache.ws.commons.axiom.wso2.version>
         <org.apache.ws.commons.schema.wso2.version>1.4.7-wso2v7</org.apache.ws.commons.schema.wso2.version>
         <org.wso2.orbit.org.apache.neethi.version>2.0.4.wso2v5</org.wso2.orbit.org.apache.neethi.version>
@@ -1398,7 +1398,7 @@
         <org.wso2.orbit.commons-codec.version>1.12.0.wso2v1</org.wso2.orbit.commons-codec.version>
         <org.apache.httpcomponents.wso2.version>4.3.3.wso2v1</org.apache.httpcomponents.wso2.version>
         <org.wso2.orbit.commons-httpclient.version>3.1.0.wso2v6</org.wso2.orbit.commons-httpclient.version>
-        <org.wso2.carbon.identity.inbound.auth.oauth2.version>6.2.7
+        <org.wso2.carbon.identity.inbound.auth.oauth2.version>6.2.20
         </org.wso2.carbon.identity.inbound.auth.oauth2.version>
         <carbon.secvault.version>5.0.13</carbon.secvault.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1374,6 +1374,14 @@
         <siddhi.io.grpc.version>1.0.3</siddhi.io.grpc.version>
         <carbon.coordination.version>2.1.1</carbon.coordination.version>
 
+        <!-- Java 11 related dependencies -->
+        <javax.annotation.version>1.3.2</javax.annotation.version>
+        <org.wso2.orbit.javax.xml.bind.version>2.3.1.wso2v1</org.wso2.orbit.javax.xml.bind.version>
+        <com.sun.xml.bind.version>2.4.0-b180830.0438</com.sun.xml.bind.version>
+        <org.apache.geronimo.spec.version>1.1</org.apache.geronimo.spec.version>
+        <com.sun.istack.version>3.0.8</com.sun.istack.version>
+        <com.sun.activation.version>1.2.0</com.sun.activation.version>
+
         <!--Apim Analytics Idp client related -->
         <feign.version>9.5.0</feign.version>
         <org.apache.axis2.wso2.version>1.6.1-wso2v37</org.apache.axis2.wso2.version>

--- a/product/distribution/carbon-home/bin/ciphertool.bat
+++ b/product/distribution/carbon-home/bin/ciphertool.bat
@@ -1,0 +1,81 @@
+@echo off
+
+REM ---------------------------------------------------------------------------
+REM   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+REM
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running CARBON."
+goto end
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\kernel-version.txt" goto noServerHome
+
+goto commandLifecycle
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:commandLifecycle
+goto findJdk
+
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk16
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk16
+
+:unknownJdk
+echo Starting WSO2 Carbon (in unsupported JDK)
+echo [ERROR] CARBON is supported only on JDK 1.8 and 11
+goto jdk16
+
+:jdk16
+goto runTool
+
+rem ----------------- Execute The Requested Command ----------------------------
+:runTool
+cd %CARBON_HOME%
+echo JAVA_HOME environment variable is set to %JAVA_HOME%
+echo CARBON_HOME environment variable is set to %CARBON_HOME%
+
+set CMD_LINE_ARGS= -Dcarbon.home="%CARBON_HOME%" -Dwso2.runtime.path="%RUNTIME_HOME%" -Dwso2.runtime="%RUNTIME%"
+java -cp "\bin\tools\*" -Dcarbon.home="%CARBON_HOME%" org.wso2.carbon.secvault.ciphertool.CipherToolInitializer %*
+
+:end
+goto endlocal
+
+:endlocal
+
+:END

--- a/product/distribution/carbon-home/bin/ciphertool.sh
+++ b/product/distribution/carbon-home/bin/ciphertool.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
+   exit 1
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+fi
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+
+cd "$CARBON_HOME";
+
+$JAVACMD \
+    -Dcarbon.home="$CARBON_HOME" \
+    -cp "bin/tools/*" org.wso2.carbon.secvault.ciphertool.CipherToolInitializer $*

--- a/product/distribution/carbon-home/bin/icf-provider.bat
+++ b/product/distribution/carbon-home/bin/icf-provider.bat
@@ -1,0 +1,81 @@
+@echo off
+
+REM ---------------------------------------------------------------------------
+REM   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+REM
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running CARBON."
+goto end
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\kernel-version.txt" goto noServerHome
+
+goto commandLifecycle
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:commandLifecycle
+goto findJdk
+
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk16
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk16
+
+:unknownJdk
+echo Starting WSO2 Carbon (in unsupported JDK)
+echo [ERROR] CARBON is supported only on JDK 1.8 and 11
+goto jdk16
+
+:jdk16
+goto runTool
+
+:runTool
+
+set CURRENT_DIR=%cd%
+
+cd %CARBON_HOME%\bin
+echo JAVA_HOME environment variable is set to %JAVA_HOME%
+echo CARBON_HOME environment variable is set to %CARBON_HOME%
+java -cp ".\*;..\bin\tools\*" -Dcarbon.home="%CARBON_HOME" -Dwso2.carbon.tool="icf-provider" org.wso2.carbon.tools.CarbonToolExecutor %1 %2 %3 %4
+
+:end
+goto endlocal
+
+:endlocal
+
+:END

--- a/product/distribution/carbon-home/bin/icf-provider.sh
+++ b/product/distribution/carbon-home/bin/icf-provider.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2019, WSO7 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
+   exit 1
+fi
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+
+# get the current directory from which the script is executed
+CURRENT_DIR=${PWD};
+
+cd "$CARBON_HOME/bin/";
+java -cp "../bin/tools/*" -Dcarbon.home="$CARBON_HOME" -Dwso2.carbon.tool="icf-provider" org.wso2.carbon.tools.CarbonToolExecutor $1 $2 $3 $4

--- a/product/distribution/carbon-home/bin/jartobundle.bat
+++ b/product/distribution/carbon-home/bin/jartobundle.bat
@@ -1,0 +1,81 @@
+@echo off
+
+REM ---------------------------------------------------------------------------
+REM   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+REM
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running CARBON."
+goto end
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\kernel-version.txt" goto noServerHome
+
+goto commandLifecycle
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:commandLifecycle
+goto findJdk
+
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk16
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk16
+
+:unknownJdk
+echo Starting WSO2 Carbon (in unsupported JDK)
+echo [ERROR] CARBON is supported only on JDK 1.8 and 11
+goto jdk16
+
+:jdk16
+goto runTool
+
+:runTool
+
+set CURRENT_DIR=%cd%
+
+cd %CARBON_HOME%\bin
+echo JAVA_HOME environment variable is set to %JAVA_HOME%
+echo CARBON_HOME environment variable is set to %CARBON_HOME%
+java -cp ".\*;..\bin\tools\*" -Dwso2.carbon.tool="jar-to-bundle-converter" org.wso2.carbon.tools.CarbonToolExecutor "%1" "%2" "%CURRENT_DIR%"
+
+:end
+goto endlocal
+
+:endlocal
+
+:END

--- a/product/distribution/carbon-home/bin/jartobundle.sh
+++ b/product/distribution/carbon-home/bin/jartobundle.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
+   exit 1
+fi
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+
+# get the current directory from which the script is executed
+CURRENT_DIR=${PWD};
+
+cd "$CARBON_HOME/bin/";
+java -cp "../bin/tools/*" -Dwso2.carbon.tool="jar-to-bundle-converter" org.wso2.carbon.tools.CarbonToolExecutor "$1" "$2" "$CURRENT_DIR"

--- a/product/distribution/carbon-home/bin/osgi-lib.bat
+++ b/product/distribution/carbon-home/bin/osgi-lib.bat
@@ -1,0 +1,78 @@
+@echo off
+
+REM ---------------------------------------------------------------------------
+REM   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+REM
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running CARBON."
+goto end
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\kernel-version.txt" goto noServerHome
+
+goto commandLifecycle
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:commandLifecycle
+goto findJdk
+
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk16
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk16
+
+:unknownJdk
+echo Starting WSO2 Carbon (in unsupported JDK)
+echo [ERROR] CARBON is supported only on JDK 1.8 and 11
+goto jdk16
+
+:jdk16
+goto runTool
+
+:runTool
+cd %CARBON_HOME%\bin
+echo JAVA_HOME environment variable is set to %JAVA_HOME%
+echo CARBON_HOME environment variable is set to %CARBON_HOME%
+java -cp ".\*;..\bin\tools\*;..\bin\bootstrap\*" -Dwso2.carbon.tool="osgi-lib-deployer" org.wso2.carbon.tools.CarbonToolExecutor "%1" "%CARBON_HOME%"
+
+:end
+goto endlocal
+
+:endlocal
+
+:END

--- a/product/distribution/carbon-home/bin/osgi-lib.sh
+++ b/product/distribution/carbon-home/bin/osgi-lib.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
+   exit 1
+fi
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+
+cd "$CARBON_HOME/bin/";
+
+java -cp "../bin/tools/*:../bin/bootstrap/*" -Dwso2.carbon.tool="osgi-lib-deployer" org.wso2.carbon.tools.CarbonToolExecutor "$1" "$CARBON_HOME"

--- a/product/distribution/carbon-home/runtime/dashboard/carbon.bat
+++ b/product/distribution/carbon-home/runtime/dashboard/carbon.bat
@@ -146,13 +146,13 @@ rem find the version of the jdk
 set CMD=RUN %*
 
 :checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8]" >NUL
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
 IF ERRORLEVEL 1 goto unknownJdk
 goto jdk16
 
 :unknownJdk
 echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8
+echo [ERROR] CARBON is supported only on JDK 1.8 and 11
 goto jdk16
 
 :jdk16
@@ -167,9 +167,16 @@ rem ---------- Add jars to classpath ----------------
 
 set CARBON_CLASSPATH="%CARBON_HOME%\bin\bootstrap\*";%CARBON_CLASSPATH%
 
+PATH %PATH%;%JAVA_HOME%\bin\
+for /f tokens^=2-5^ delims^=.-_^" %%j in ('java -fullversion 2^>^&1') do set "jver=%%j%%k%%l%%m"
+
+set JAVA_VER_BASED_OPTS
+
 set JAVA_ENDORSED="%CARBON_HOME%\bin\bootstrap\endorsed";"%JAVA_HOME%\jre\lib\endorsed";"%JAVA_HOME%\lib\endorsed"
 
-set CMD_LINE_ARGS=-Xbootclasspath/a:%CARBON_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%RUNTIME_HOME%\logs\heap-dump.hprof" -Dcom.sun.management.jmxremote -classpath %CARBON_CLASSPATH% %JAVA_OPTS% -Djava.endorsed.dirs=%JAVA_ENDORSED% -Dcarbon.home="%CARBON_HOME%" -Dwso2.runtime.path="%RUNTIME_HOME%" -Dwso2.runtime="%RUNTIME%" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Djava.io.tmpdir="%CARBON_HOME%\tmp" -Dcarbon.classpath=%CARBON_CLASSPATH% -Dfile.encoding=UTF8 -Djavax.net.ssl.keyStore="%CARBON_HOME%\resources\security\wso2carbon.jks" -Djavax.net.ssl.keyStorePassword="wso2carbon" -Djavax.net.ssl.trustStore="%CARBON_HOME%\resources\security\client-truststore.jks" -Djavax.net.ssl.trustStorePassword="wso2carbon"
+if %jver% LSS 11000 set JAVA_VER_BASED_OPTS="-Djava.endorsed.dirs=%JAVA_ENDORSED_DIRS%"
+
+set CMD_LINE_ARGS=-Xbootclasspath/a:%CARBON_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%RUNTIME_HOME%\logs\heap-dump.hprof" -Dcom.sun.management.jmxremote -classpath %CARBON_CLASSPATH% %JAVA_OPTS% %JAVA_VER_BASED_OPTS% -Dcarbon.home="%CARBON_HOME%" -Dwso2.runtime.path="%RUNTIME_HOME%" -Dwso2.runtime="%RUNTIME%" -Djavax.xml.bind.JAXBContextFactory="com.sun.xml.bind.v2.ContextFactory" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Djava.io.tmpdir="%CARBON_HOME%\tmp" -Dcarbon.classpath=%CARBON_CLASSPATH% -Dfile.encoding=UTF8  -Djavax.net.ssl.keyStore="%CARBON_HOME%\resources\security\wso2carbon.jks" -Djavax.net.ssl.keyStorePassword="wso2carbon" -Djavax.net.ssl.trustStore="%CARBON_HOME%\resources\security\client-truststore.jks" -Djavax.net.ssl.trustStorePassword="wso2carbon"
 
 :runJava
 echo JAVA_HOME environment variable is set to %JAVA_HOME%

--- a/product/distribution/carbon-home/runtime/dashboard/carbon.sh
+++ b/product/distribution/carbon-home/runtime/dashboard/carbon.sh
@@ -212,10 +212,11 @@ elif [ "$CMD" = "version" ]; then
 fi
 
 # ---------- Handle the SSL Issue with proper JDK version --------------------
-jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
-if [ "$jdk_18" = "" ]; then
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8"
+   echo " [ERROR] CARBON is supported only on JDK 1.8 and 11"
 fi
 
 CARBON_XBOOTCLASSPATH=""
@@ -248,7 +249,9 @@ if $cygwin; then
   CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
   RUNTIME_HOME=`cygpath --absolute --windows "$RUNTIME_HOME"`
   CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
-  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  if [ $java_version_formatted -le 0108 ]; then
+    JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  fi
   CARBON_CLASSPATH=`cygpath --path --windows "$CARBON_CLASSPATH"`
   CARBON_XBOOTCLASSPATH=`cygpath --path --windows "$CARBON_XBOOTCLASSPATH"`
 fi
@@ -267,6 +270,15 @@ status=$START_EXIT_STATUS
 #To monitor a Carbon server in remote JMX mode on linux host machines, set the below system property.
 #   -Djava.rmi.server.hostname="your.IP.goes.here"
 
+JAVA_VER_BASED_OPTS=""
+if [ $java_version_formatted -le 0108 ]; then
+    JAVA_VER_BASED_OPTS="-Djava.endorsed.dirs=$JAVA_ENDORSED_DIRS"
+fi
+
+if [ $java_version_formatted -ge 1100 ] ; then
+    JAVA_VER_BASED_OPTS="--add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED"
+fi
+
 while [ "$status" = "$START_EXIT_STATUS" ]
 do
     $JAVACMD \
@@ -276,13 +288,14 @@ do
     -XX:HeapDumpPath="$RUNTIME_HOME/logs/heap-dump.hprof" \
     $JAVA_OPTS \
     -classpath "$CARBON_CLASSPATH" \
-    -Djava.endorsed.dirs="$JAVA_ENDORSED_DIRS" \
+    $JAVA_VER_BASED_OPTS \
     -Djava.io.tmpdir="$CARBON_HOME/tmp" \
     -Dcarbon.registry.root=/ \
     -Djava.command="$JAVACMD" \
     -Dcarbon.home="$CARBON_HOME" \
     -Dwso2.runtime.path="$RUNTIME_HOME" \
     -Dwso2.runtime="$RUNTIME" \
+    -Djavax.xml.bind.JAXBContextFactory="com.sun.xml.bind.v2.ContextFactory" \
     -Djava.util.logging.config.file="$RUNTIME_HOME/bin/bootstrap/logging.properties" \
     -Djava.security.egd=file:/dev/./urandom \
     -Dfile.encoding=UTF8 \

--- a/product/distribution/carbon-home/runtime/worker/carbon.bat
+++ b/product/distribution/carbon-home/runtime/worker/carbon.bat
@@ -146,13 +146,13 @@ rem find the version of the jdk
 set CMD=RUN %*
 
 :checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8]" >NUL
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
 IF ERRORLEVEL 1 goto unknownJdk
 goto jdk16
 
 :unknownJdk
 echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8
+echo [ERROR] CARBON is supported only on JDK 1.8 and 11
 goto jdk16
 
 :jdk16
@@ -167,9 +167,17 @@ rem ---------- Add jars to classpath ----------------
 
 set CARBON_CLASSPATH="%CARBON_HOME%\bin\bootstrap\*";%CARBON_CLASSPATH%
 
+PATH %PATH%;%JAVA_HOME%\bin\
+for /f tokens^=2-5^ delims^=.-_^" %%j in ('java -fullversion 2^>^&1') do set "jver=%%j%%k%%l%%m"
+
+set JAVA_VER_BASED_OPTS
+
 set JAVA_ENDORSED="%CARBON_HOME%\bin\bootstrap\endorsed";"%JAVA_HOME%\jre\lib\endorsed";"%JAVA_HOME%\lib\endorsed"
 
-set CMD_LINE_ARGS=-Xbootclasspath/a:%CARBON_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%RUNTIME_HOME%\logs\heap-dump.hprof" -Dcom.sun.management.jmxremote -classpath %CARBON_CLASSPATH% %JAVA_OPTS% -Djava.endorsed.dirs=%JAVA_ENDORSED% -Dcarbon.home="%CARBON_HOME%" -Dwso2.runtime.path="%RUNTIME_HOME%" -Dwso2.runtime="%RUNTIME%" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Djava.io.tmpdir="%CARBON_HOME%\tmp" -Dcarbon.classpath=%CARBON_CLASSPATH% -Dfile.encoding=UTF8 -Djavax.net.ssl.keyStore="%CARBON_HOME%\resources\security\wso2carbon.jks" -Djavax.net.ssl.keyStorePassword="wso2carbon" -Djavax.net.ssl.trustStore="%CARBON_HOME%\resources\security\client-truststore.jks" -Djavax.net.ssl.trustStorePassword="wso2carbon"
+if %jver% LSS 11000 set JAVA_VER_BASED_OPTS="-Djava.endorsed.dirs=%JAVA_ENDORSED_DIRS%"
+
+set CMD_LINE_ARGS=-Xbootclasspath/a:%CARBON_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError
+-XX:HeapDumpPath="%RUNTIME_HOME%\logs\heap-dump.hprof" -Dcom.sun.management.jmxremote -classpath %CARBON_CLASSPATH% %JAVA_OPTS% %JAVA_VER_BASED_OPTS% -Dcarbon.home="%CARBON_HOME%" -Dwso2.runtime.path="%RUNTIME_HOME%" -Dwso2.runtime="%RUNTIME%" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Djavax.xml.bind.JAXBContextFactory="com.sun.xml.bind.v2.ContextFactory" -Djava.io.tmpdir="%CARBON_HOME%\tmp" -Dcarbon.classpath=%CARBON_CLASSPATH% -Dfile.encoding=UTF8  -Djavax.net.ssl.keyStore="%CARBON_HOME%\resources\security\wso2carbon.jks" -Djavax.net.ssl.keyStorePassword="wso2carbon" -Djavax.net.ssl.trustStore="%CARBON_HOME%\resources\security\client-truststore.jks" -Djavax.net.ssl.trustStorePassword="wso2carbon"
 
 :runJava
 echo JAVA_HOME environment variable is set to %JAVA_HOME%

--- a/product/distribution/carbon-home/runtime/worker/carbon.sh
+++ b/product/distribution/carbon-home/runtime/worker/carbon.sh
@@ -212,10 +212,11 @@ elif [ "$CMD" = "version" ]; then
 fi
 
 # ---------- Handle the SSL Issue with proper JDK version --------------------
-jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
-if [ "$jdk_18" = "" ]; then
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8"
+   echo " [ERROR] CARBON is supported only on JDK 1.8 and 11"
 fi
 
 CARBON_XBOOTCLASSPATH=""
@@ -248,7 +249,9 @@ if $cygwin; then
   CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
   RUNTIME_HOME=`cygpath --absolute --windows "$RUNTIME_HOME"`
   CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
-  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  if [ $java_version_formatted -le 0108 ]; then
+    JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  fi
   CARBON_CLASSPATH=`cygpath --path --windows "$CARBON_CLASSPATH"`
   CARBON_XBOOTCLASSPATH=`cygpath --path --windows "$CARBON_XBOOTCLASSPATH"`
 fi
@@ -267,6 +270,15 @@ status=$START_EXIT_STATUS
 #To monitor a Carbon server in remote JMX mode on linux host machines, set the below system property.
 #   -Djava.rmi.server.hostname="your.IP.goes.here"
 
+JAVA_VER_BASED_OPTS=""
+if [ $java_version_formatted -le 0108 ]; then
+    JAVA_VER_BASED_OPTS="-Djava.endorsed.dirs=$JAVA_ENDORSED_DIRS"
+fi
+
+if [ $java_version_formatted -ge 1100 ] ; then
+    JAVA_VER_BASED_OPTS="--add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED"
+fi
+
 while [ "$status" = "$START_EXIT_STATUS" ]
 do
     $JAVACMD \
@@ -276,13 +288,14 @@ do
     -XX:HeapDumpPath="$RUNTIME_HOME/logs/heap-dump.hprof" \
     $JAVA_OPTS \
     -classpath "$CARBON_CLASSPATH" \
-    -Djava.endorsed.dirs="$JAVA_ENDORSED_DIRS" \
+    $JAVA_VER_BASED_OPTS \
     -Djava.io.tmpdir="$CARBON_HOME/tmp" \
     -Dcarbon.registry.root=/ \
     -Djava.command="$JAVACMD" \
     -Dcarbon.home="$CARBON_HOME" \
     -Dwso2.runtime.path="$RUNTIME_HOME" \
     -Dwso2.runtime="$RUNTIME" \
+    -Djavax.xml.bind.JAXBContextFactory="com.sun.xml.bind.v2.ContextFactory" \
     -Djava.util.logging.config.file="$RUNTIME_HOME/bin/bootstrap/logging.properties" \
     -Djava.security.egd=file:/dev/./urandom \
     -Dfile.encoding=UTF8 \

--- a/product/distribution/pom.xml
+++ b/product/distribution/pom.xml
@@ -428,6 +428,57 @@
                             <overWriteSnapshots>true</overWriteSnapshots>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>copy2</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <!--Java 11 related dependencies-->
+                                <artifactItem>
+                                    <groupId>javax.annotation</groupId>
+                                    <artifactId>javax.annotation-api</artifactId>
+                                    <version>${javax.annotation.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wso2.orbit.javax.xml.bind</groupId>
+                                    <artifactId>jaxb-api</artifactId>
+                                    <version>${org.wso2.orbit.javax.xml.bind.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.xml.bind</groupId>
+                                    <artifactId>jaxb-impl</artifactId>
+                                    <version>${com.sun.xml.bind.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.geronimo.specs</groupId>
+                                    <artifactId>geronimo-activation_1.1_spec</artifactId>
+                                    <version>${org.apache.geronimo.spec.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.istack</groupId>
+                                    <artifactId>istack-commons-runtime</artifactId>
+                                    <version>${com.sun.istack.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.activation</groupId>
+                                    <artifactId>javax.activation</artifactId>
+                                    <version>${com.sun.activation.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}/java-dependencies</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/product/distribution/pom.xml
+++ b/product/distribution/pom.xml
@@ -416,6 +416,12 @@
                                     <version>${siddhi.store.rdbms.version}</version>
                                     <type>jar</type>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>io.siddhi.extension.io.grpc</groupId>
+                                    <artifactId>siddhi-io-grpc</artifactId>
+                                    <version>${siddhi.io.grpc.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
                             </artifactItems>
                             <outputDirectory>${project.build.directory}/extensions</outputDirectory>
                             <overWriteReleases>false</overWriteReleases>

--- a/product/distribution/src/assembly/bin.xml
+++ b/product/distribution/src/assembly/bin.xml
@@ -31,6 +31,14 @@
                 <exclude>README.txt</exclude>
                 <exclude>LICENSE.txt</exclude>
                 <exclude>bin/carbon.sh</exclude>
+                <exclude>bin/ciphertool.sh</exclude>
+                <exclude>bin/ciphertool.bat</exclude>
+                <exclude>bin/icf-provider.bat</exclude>
+                <exclude>bin/icf-provider.sh</exclude>
+                <exclude>bin/jartobundle.sh</exclude>
+                <exclude>bin/jartobundle.bat</exclude>
+                <exclude>bin/osgi-lib.bat</exclude>
+                <exclude>bin/osgi-lib.sh</exclude>
                 <exclude>release-notes.html</exclude>
                 <exclude>conf/osgi/launch.properties</exclude>
                 <exclude>conf/deployment.yaml</exclude>
@@ -87,15 +95,6 @@
             <directory>carbon-home/bin</directory>
             <outputDirectory>bin</outputDirectory>
             <includes>
-                <include>**/*.sh</include>
-                <include>**/*.bat</include>
-            </includes>
-            <fileMode>755</fileMode>
-        </fileSet>
-        <fileSet>
-            <directory>carbon-home/bin</directory>
-            <outputDirectory>bin</outputDirectory>
-            <includes>
                 <include>**/*.txt</include>
             </includes>
             <fileMode>444</fileMode>
@@ -128,6 +127,11 @@
             </excludes>
         </fileSet>
         <fileSet>
+            <directory>carbon-home/bin</directory>
+            <outputDirectory>bin</outputDirectory>
+            <fileMode>755</fileMode>
+        </fileSet>
+        <fileSet>
             <directory>.</directory>
             <outputDirectory>wso2/worker/deployment/csv-files</outputDirectory>
             <excludes>
@@ -141,6 +145,14 @@
             <excludes>
                 <exclude>*/**</exclude>
             </excludes>
+            <fileMode>644</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>target/java-dependencies</directory>
+            <outputDirectory>bin/bootstrap</outputDirectory>
+            <includes>
+                <include>**/*.jar</include>
+            </includes>
             <fileMode>644</fileMode>
         </fileSet>
         <fileSet>


### PR DESCRIPTION
## Purpose
This PR mainly adds the Java 11 support for analytics-apim distribution. The following PRs were referred when adding the Java 11 support.

https://github.com/wso2/streaming-integrator/pull/25
https://github.com/wso2/streaming-integrator/pull/38
https://github.com/wso2/streaming-integrator/pull/49
https://github.com/wso2/streaming-integrator/pull/50

Utility scripts were specifically added to support for Java 11. The reason for that is that the utility scripts coming from the Kernel do not support Java 11. Until the said support is added to the Kernel level, we will use a copy of those scrips in the analytics-apim repo.

Also, this PR adds siddhi-io-grpc extension.

## Goals
Add support for Java 11.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/wso2/streaming-integrator/pull/25
https://github.com/wso2/streaming-integrator/pull/38
https://github.com/wso2/streaming-integrator/pull/49
https://github.com/wso2/streaming-integrator/pull/50

## Test environment
openjdk version "1.8.0_212"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_212-b04)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.212-b04, mixed mode)

openjdk version "11.0.4" 2019-07-16
OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.4+11)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.4+11, mixed mode)

MacOs Catalina 10.15