### PR TITLE
Rename dashboard app from portal to analytics-dashboards

### DIFF
--- a/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClientConstants.java
+++ b/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClientConstants.java
@@ -63,7 +63,7 @@ public class ApimIdPClientConstants {
     public static final String DEFAULT_KM_USERNAME = "admin";
     public static final String DEFAULT_KM_PASSWORD = "admin";
     public static final String DEFAULT_SP_APP_CONTEXT = "sp";
-    public static final String DEFAULT_PORTAL_APP_CONTEXT = "portal";
+    public static final String DEFAULT_PORTAL_APP_CONTEXT = "analytics-dashboard";
     public static final String DEFAULT_BR_DB_APP_CONTEXT = "business-rules";
     public static final String DEFAULT_CACHE_TIMEOUT = "900";
     public static final String DEFAULT_CONNECTION_TIMEOUT = "10000";
@@ -73,14 +73,12 @@ public class ApimIdPClientConstants {
     public static final String POST_LOGOUT_REDIRECT_URI_PHRASE = "&post_logout_redirect_uri=";
 
     public static final String AUTHENTICATION_ADMIN_SERVICE_ENDPOINT_POSTFIX = "/services/AuthenticationAdmin";
-    public static final String REMOTE_USER_STORE_MANAGER_SERVICE_ENDPOINT_POSTFIX
-            = "/services/RemoteUserStoreManagerService";
     public static final String OAUTH_ADMIN_SERVICE_ENDPOINT_POSTFIX = "/services/OAuthAdminService";
 
     public static final String REDIRECT_URL = "Redirect_Url";
 
     public static final String SP_APP_NAME = "sp";
-    public static final String PORTAL_APP_NAME = "sp_portal";
+    public static final String PORTAL_APP_NAME = "sp_analytics_dashboard";
     public static final String BR_DB_APP_NAME = "sp_business_rules";
 
     public static final String INTROSPECTION_URL = "introspectionUrl";

--- a/features/org.wso2.analytics.apim.feature/pom.xml
+++ b/features/org.wso2.analytics.apim.feature/pom.xml
@@ -252,7 +252,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMApiCreated/**</includes>
                                 </artifactItem>
@@ -262,7 +262,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMAppCreated/**</includes>
                                 </artifactItem>
@@ -272,7 +272,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMSubscriptions/**</includes>
                                 </artifactItem>
@@ -282,7 +282,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMDeveloperSignups/**</includes>
                                 </artifactItem>
@@ -292,7 +292,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMTopApiCreators/**</includes>
                                 </artifactItem>
@@ -302,7 +302,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMTopAppCreators/**</includes>
                                 </artifactItem>
@@ -312,7 +312,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMTopAppUsers/**</includes>
                                 </artifactItem>
@@ -322,7 +322,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMTopSubscribers/**</includes>
                                 </artifactItem>
@@ -332,7 +332,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMOverallApiStats/**</includes>
                                 </artifactItem>
@@ -342,7 +342,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMApiCreatedAnalytics/**</includes>
                                 </artifactItem>
@@ -352,7 +352,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMAppCreatedAnalytics/**</includes>
                                 </artifactItem>
@@ -362,7 +362,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMAppApiUsage/**</includes>
                                 </artifactItem>
@@ -372,7 +372,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMAppResourceUsage/**</includes>
                                 </artifactItem>
@@ -382,7 +382,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMFaultyPerApp/**</includes>
                                 </artifactItem>
@@ -392,7 +392,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMSubscriptionsAnalytics/**</includes>
                                 </artifactItem>
@@ -402,7 +402,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMSignupsAnalytics/**</includes>
                                 </artifactItem>
@@ -412,7 +412,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMTopApiUsers/**</includes>
                                 </artifactItem>
@@ -422,7 +422,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMApiVersionUsageSummary/**</includes>
                                 </artifactItem>
@@ -432,7 +432,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMApiResourceUsageSummary/**</includes>
                                 </artifactItem>
@@ -442,7 +442,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMApiBackendUsageSummary/**</includes>
                                 </artifactItem>
@@ -452,7 +452,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMApiLastAccessSummary/**</includes>
                                 </artifactItem>
@@ -462,7 +462,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMApiResponseSummary/**</includes>
                                 </artifactItem>
@@ -472,7 +472,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMOverallApiUsage/**</includes>
                                 </artifactItem>
@@ -482,7 +482,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMRegisteredAppUsers/**</includes>
                                 </artifactItem>
@@ -492,7 +492,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMTopFaultyApis/**</includes>
                                 </artifactItem>
@@ -502,7 +502,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMTopThrottledOutApis/**</includes>
                                 </artifactItem>
@@ -512,7 +512,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMTopUserAgents/**</includes>
                                 </artifactItem>
@@ -522,7 +522,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMTopPlatforms/**</includes>
                                 </artifactItem>
@@ -532,7 +532,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMApiLatencyTime/**</includes>
                                 </artifactItem>
@@ -542,7 +542,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>APIMGeoBasedInvocations/**</includes>
                                 </artifactItem>
@@ -553,7 +553,7 @@
                                     <version>${project.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/target/portal/extensions/widgets/
+                                    <outputDirectory>${project.build.directory}/target/analytics-dashboard/extensions/widgets/
                                     </outputDirectory>
                                     <includes>DateRangePicker/**</includes>
                                 </artifactItem>

--- a/features/org.wso2.analytics.apim.feature/src/main/resources/p2.inf
+++ b/features/org.wso2.analytics.apim.feature/src/main/resources/p2.inf
@@ -38,10 +38,10 @@ org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/das
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/resources/dashboards/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/);\
-org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/portal/);\
-org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/portal/extensions/);\
-org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/portal/extensions/widgets/);\
-org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.analytics.apim_${feature.version}/portal/extensions/widgets/,target:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/portal/extensions/widgets/,overwrite:true);\
+org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/analytics-dashboard/);\
+org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/analytics-dashboard/extensions/);\
+org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/analytics-dashboard/extensions/widgets/);\
+org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.analytics.apim_${feature.version}/analytics-dashboard/extensions/widgets/,target:${installFolder}/../../wso2/dashboard/deployment/web-ui-apps/analytics-dashboard/extensions/widgets/,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.analytics.apim_${feature.version}/dashboard/apimpublisher.json,target:${installFolder}/../../wso2/dashboard/resources/dashboards/apimpublisher.json,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.analytics.apim_${feature.version}/dashboard/apimstore.json,target:${installFolder}/../../wso2/dashboard/resources/dashboards/apimstore.json,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/../lib/features/org.wso2.carbon.dashboards.samples_${feature.version}/widgets/);

--- a/pom.xml
+++ b/pom.xml
@@ -1294,7 +1294,7 @@
 
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
         <!--Dashboard-->
-        <carbon.dashboards.version>4.0.70</carbon.dashboards.version>
+        <carbon.dashboards.version>4.0.71-SNAPSHOT</carbon.dashboards.version>
         <carbon.uis.version>1.0.3</carbon.uis.version>
         <maven.exec.plugin.version>1.5.0</maven.exec.plugin.version>
         <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>

--- a/product/distribution/carbon-home/conf/dashboard/deployment.yaml
+++ b/product/distribution/carbon-home/conf/dashboard/deployment.yaml
@@ -369,7 +369,7 @@ auth.configs:
     kmTokenUrl: https://localhost:9443/oauth2
     kmUsername: admin
     kmPassword: admin
-    portalAppContext: portal
+    portalAppContext: analytics-dashboard
     businessRulesAppContext : business-rules
     cacheTimeout: 900
     baseUrl: https://localhost:9643


### PR DESCRIPTION
## Purpose
Since the apim store is renamed to devportal, to avoid confusions with that and for better understanding, dashboard app name is renamed to analytics-dashboard from portal.
