### PR TITLE
Add improvements to APIM IdP client

### DIFF
--- a/components/org.wso2.analytics.apim.idp.client/pom.xml
+++ b/components/org.wso2.analytics.apim.idp.client/pom.xml
@@ -121,12 +121,8 @@
             org.wso2.carbon.analytics.idp.client.*,
             com.google.common.*,
             feign.*,
-            feign.gson.*;version="${feign.version}",
-            org.json.simple.*,
             org.osgi.framework.*;version="${osgi.framework.import.version.range}",
-            org.wso2.carbon.config.*;version="${carbon.config.version.range}",
             org.wso2.carbon.datasource.core.*;version="${org.wso2.carbon.datasource.version.range}",
-            org.wso2.carbon.kernel.*;version="${carbon.kernel.package.import.version.range}",
             org.wso2.carbon.secvault.*;version="${carbon.secvault.version}",
             *;resolution:=optional
         </import.package>

--- a/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClient.java
+++ b/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClient.java
@@ -22,6 +22,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.gson.Gson;
 import feign.Response;
 import feign.gson.GsonDecoder;
+import org.apache.axis2.AxisFault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.analytics.apim.idp.client.dto.DCRClientInfo;
@@ -39,6 +40,7 @@ import org.wso2.carbon.analytics.idp.client.external.impl.DCRMServiceStub;
 import org.wso2.carbon.analytics.idp.client.external.impl.OAuth2ServiceStubs;
 import org.wso2.carbon.analytics.idp.client.external.models.ExternalSession;
 import org.wso2.carbon.analytics.idp.client.external.models.OAuthApplicationInfo;
+import org.wso2.carbon.authenticator.stub.LoginAuthenticationExceptionException;
 import org.wso2.carbon.identity.oauth.stub.OAuthAdminServiceIdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
 
@@ -68,6 +70,10 @@ public class ApimIdPClient extends ExternalIdPClient {
     private String kmUserName;
     private String authorizeEndpoint;
     private String grantType;
+    private String adminServiceBaseUrl;
+    private String adminServiceUsername;
+    private String adminServicePassword;
+    private String uriHost;
     private String baseUrl;
     private String adminScopeName;
     private String allScopes;
@@ -79,13 +85,17 @@ public class ApimIdPClient extends ExternalIdPClient {
     // Here the user given context are mapped to the OAuthApp Info.
     private Map<String, OAuthApplicationInfo> oAuthAppInfoMap;
 
-    public ApimIdPClient(String baseUrl, String authorizeEndpoint, String grantType, String adminScopeName,
-                         String allScopes, Map<String, OAuthApplicationInfo> oAuthAppInfoMap, int cacheTimeout,
-                         String kmUserName, DCRMServiceStub dcrmServiceStub, OAuth2ServiceStubs oAuth2ServiceStubs,
-                         boolean isSSOEnabled, String ssoLogoutURL,
-                         OAuthAdminServiceClient oAuthAdminServiceClient) {
+    public ApimIdPClient(String adminServiceBaseUrl, String adminServiceUsername, String adminServicePassword,
+                         String uriHost, String baseUrl, String authorizeEndpoint, String grantType,
+                         String adminScopeName, String allScopes, Map<String, OAuthApplicationInfo> oAuthAppInfoMap,
+                         int cacheTimeout, String kmUserName, DCRMServiceStub dcrmServiceStub,
+                         OAuth2ServiceStubs oAuth2ServiceStubs, boolean isSSOEnabled, String ssoLogoutURL) {
         super(baseUrl, authorizeEndpoint, grantType, null, adminScopeName, oAuthAppInfoMap,
                 cacheTimeout, null, dcrmServiceStub, oAuth2ServiceStubs, null, null, isSSOEnabled, ssoLogoutURL);
+        this.adminServiceBaseUrl = adminServiceBaseUrl;
+        this.adminServiceUsername = adminServiceUsername;
+        this.adminServicePassword = adminServicePassword;
+        this.uriHost = uriHost;
         this.baseUrl = baseUrl;
         this.authorizeEndpoint = authorizeEndpoint;
         this.grantType = grantType;
@@ -105,6 +115,33 @@ public class ApimIdPClient extends ExternalIdPClient {
 
     @Override
     public void init(String kmUserName) throws IdPClientException {
+        /*
+        * Service clients are created inside init (which is called in login method) in order to prevent error logs
+        * printed when the dashboard runtime started without starting APIM server.
+        * */
+        LoginAdminServiceClient login;
+        String session;
+        try {
+            login = new LoginAdminServiceClient(this.adminServiceBaseUrl);
+            session = login.authenticate(this.adminServiceUsername, this.adminServicePassword, this.uriHost);
+        } catch (AxisFault axisFault) {
+            String error = "Error occurred while creating Login admin Service Client.";
+            LOG.error(error);
+            throw new IdPClientException(error, axisFault.getCause());
+        } catch (RemoteException | LoginAuthenticationExceptionException e) {
+            String error = "Error occurred while authenticating admin user using Login admin Service Client.";
+            LOG.error(error);
+            throw new IdPClientException(error, e);
+        }
+        try {
+            this.oAuthAdminServiceClient = new OAuthAdminServiceClient(this.adminServiceBaseUrl,
+                    this.adminServiceUsername, this.adminServicePassword, session);
+        } catch (AxisFault axisFault) {
+            String error = "Error occurred while creating OAuth Admin Service Client.";
+            LOG.error(error);
+            throw new IdPClientException(error, axisFault.getCause());
+        }
+
         for (Map.Entry<String, OAuthApplicationInfo> entry : this.oAuthAppInfoMap.entrySet()) {
             String appContext = entry.getKey();
             OAuthApplicationInfo oAuthApp = entry.getValue();

--- a/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClientConstants.java
+++ b/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClientConstants.java
@@ -59,7 +59,7 @@ public class ApimIdPClientConstants {
     public static final String DEFAULT_ADMIN_SERVICE_BASE_URL = "https://localhost:9443";
     public static final String DEFAULT_BASE_URL = "https://localhost:9643";
     public static final String DEFAULT_KM_TOKEN_URL = "https://localhost:9443/oauth2";
-    public static final String DEFAULT_KM_DCR_URL = "https://localhost:9443/client-registration/v0.14/register";
+    public static final String DEFAULT_KM_DCR_URL = "https://localhost:9443/client-registration/v0.15/register";
     public static final String DEFAULT_KM_USERNAME = "admin";
     public static final String DEFAULT_KM_PASSWORD = "admin";
     public static final String DEFAULT_SP_APP_CONTEXT = "sp";

--- a/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClientFactory.java
+++ b/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClientFactory.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.analytics.apim.idp.client;
 
-import org.apache.axis2.AxisFault;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -36,13 +35,11 @@ import org.wso2.carbon.analytics.idp.client.core.utils.config.IdPClientConfigura
 import org.wso2.carbon.analytics.idp.client.external.impl.DCRMServiceStub;
 import org.wso2.carbon.analytics.idp.client.external.impl.OAuth2ServiceStubs;
 import org.wso2.carbon.analytics.idp.client.external.models.OAuthApplicationInfo;
-import org.wso2.carbon.authenticator.stub.LoginAuthenticationExceptionException;
 import org.wso2.carbon.datasource.core.api.DataSourceService;
 import org.wso2.carbon.secvault.SecretRepository;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.rmi.RemoteException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -253,33 +250,9 @@ public class ApimIdPClientFactory implements IdPClientFactory {
         String targetURIForRedirection = properties.getOrDefault(ApimIdPClientConstants.EXTERNAL_SSO_LOGOUT_URL,
                             ApimIdPClientConstants.DEFAULT_EXTERNAL_SSO_LOGOUT_URL);
 
-        LoginAdminServiceClient login;
-        String session;
-        try {
-            login = new LoginAdminServiceClient(adminServiceBaseUrl);
-            session = login.authenticate(adminServiceUsername, adminServicePassword, uriHost);
-        } catch (AxisFault axisFault) {
-            String error = "Error occurred while creating Login admin Service Client.";
-            LOG.error(error);
-            throw new IdPClientException(error, axisFault.getCause());
-        } catch (RemoteException | LoginAuthenticationExceptionException e) {
-            String error = "Error occurred while authenticating admin user using Login admin Service Client.";
-            LOG.error(error);
-            throw new IdPClientException(error, e);
-        }
-        OAuthAdminServiceClient oAuthAdminServiceClient;
-        try {
-            oAuthAdminServiceClient
-                    = new OAuthAdminServiceClient(adminServiceBaseUrl, session);
-        } catch (AxisFault axisFault) {
-            String error = "Error occurred while creating OAuth Admin Service Client.";
-            LOG.error(error);
-            throw new IdPClientException(error, axisFault.getCause());
-        }
-
-        return new ApimIdPClient(baseUrl, kmTokenUrl + ApimIdPClientConstants.AUTHORIZE_POSTFIX, grantType,
-                adminScopeName, allScopes, oAuthAppInfoMap, cacheTimeout, dcrAppOwner, dcrmServiceStub,
-                keyManagerServiceStubs, idPClientConfiguration.isSsoEnabled(), targetURIForRedirection,
-                oAuthAdminServiceClient);
+        return new ApimIdPClient(adminServiceBaseUrl, adminServiceUsername, adminServicePassword, uriHost, baseUrl,
+                kmTokenUrl + ApimIdPClientConstants.AUTHORIZE_POSTFIX, grantType, adminScopeName, allScopes,
+                oAuthAppInfoMap, cacheTimeout, dcrAppOwner, dcrmServiceStub, keyManagerServiceStubs,
+                idPClientConfiguration.isSsoEnabled(), targetURIForRedirection);
     }
 }

--- a/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/OAuthAdminServiceClient.java
+++ b/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/OAuthAdminServiceClient.java
@@ -20,11 +20,15 @@ package org.wso2.analytics.apim.idp.client;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.client.Options;
 import org.apache.axis2.client.ServiceClient;
+import org.apache.commons.httpclient.Header;
 import org.wso2.carbon.identity.oauth.stub.OAuthAdminServiceIdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.stub.OAuthAdminServiceStub;
 import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
 
+import java.nio.charset.StandardCharsets;
 import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Base64;
 
 import static org.apache.axis2.transport.http.HTTPConstants.COOKIE_STRING;
 import static org.wso2.analytics.apim.idp.client.ApimIdPClientConstants.OAUTH_ADMIN_SERVICE_ENDPOINT_POSTFIX;
@@ -35,13 +39,21 @@ import static org.wso2.analytics.apim.idp.client.ApimIdPClientConstants.OAUTH_AD
 public class OAuthAdminServiceClient {
   private OAuthAdminServiceStub oAuthAdminServiceStub;
 
-  public OAuthAdminServiceClient(String adminServiceBaseUrl, String sessionCookie) throws AxisFault {
+  public OAuthAdminServiceClient(String adminServiceBaseUrl, String adminServiceUsername, String adminServicePassword,
+                                 String sessionCookie) throws AxisFault {
     String endPoint = adminServiceBaseUrl + OAUTH_ADMIN_SERVICE_ENDPOINT_POSTFIX;
     oAuthAdminServiceStub = new OAuthAdminServiceStub(endPoint);
 
     ServiceClient serviceClient = oAuthAdminServiceStub._getServiceClient();
     Options option = serviceClient.getOptions();
-    option.setManageSession(true); 
+    option.setManageSession(true);
+    String userNamePassword = adminServiceUsername + ":" + adminServicePassword;
+    String encodedString = Base64.getEncoder().encodeToString(userNamePassword.getBytes(StandardCharsets.UTF_8));
+    String authorizationHeader = "Basic " + encodedString;
+    ArrayList<Header> headers = new ArrayList<>();
+    Header authHeader = new Header("Authorization", authorizationHeader);
+    headers.add(authHeader);
+    option.setProperty("HTTP_HEADERS", headers);
     option.setProperty(COOKIE_STRING, sessionCookie);
   } 
    


### PR DESCRIPTION
## Purpose
This PR adds improvements to the APIM IdP client.

Furthermore, the login client is created only when login method is called. Otherwise, if someone starts dashboard runtime before starting the APIM server, error logs will be printed saying that cannot create a login service client.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes