### PR TITLE
Enabling gRPC service using deployment yaml

### DIFF
--- a/features/org.wso2.analytics.apim.feature/src/main/resources/siddhi-files/APIM_EVENT_RECEIVER.siddhi
+++ b/features/org.wso2.analytics.apim.feature/src/main/resources/siddhi-files/APIM_EVENT_RECEIVER.siddhi
@@ -29,6 +29,7 @@ define stream workflowStream(
     updatedTime long
 );
 
+@source(ref='grpcSource', enable.ssl="TRUE" , @map(type='json'))
 @source(type = 'mgwfile', wso2.stream.id = 'org.wso2.apimgt.statistics.request:3.0.0', @map(type = 'wso2event'))
 @source(type = 'wso2event', wso2.stream.id = 'org.wso2.apimgt.statistics.request:3.0.0', @map(type = 'wso2event'))
 define stream InComingRequestStream (meta_clientType string,
@@ -69,6 +70,7 @@ define stream InComingRequestStream (meta_clientType string,
     gatewayType string,
     label string);
 
+@source(ref='grpcSource', enable.ssl="TRUE" , @map(type='json'))
 @source(type = 'mgwfile', wso2.stream.id = 'org.wso2.apimgt.statistics.throttle:3.0.0', @map(type = 'wso2event'))
 @source(type = 'wso2event', wso2.stream.id = 'org.wso2.apimgt.statistics.throttle:3.0.0',
 	@map(type = 'wso2event'))
@@ -109,6 +111,7 @@ define stream ThrottledOutStream(
     hostname string
 );
 
+@source(ref='grpcSource', enable.ssl="TRUE" , @map(type='json'))
 @source(type = 'mgwfile', wso2.stream.id = 'org.wso2.apimgt.statistics.fault:3.0.0', @map(type = 'wso2event'))
 @source(type = 'wso2event', wso2.stream.id = 'org.wso2.apimgt.statistics.fault:3.0.0',
 	@map(type = 'wso2event'))

--- a/product/distribution/carbon-home/conf/worker/deployment.yaml
+++ b/product/distribution/carbon-home/conf/worker/deployment.yaml
@@ -424,6 +424,12 @@ wso2.datasources:
           validationTimeout: 30000
 
 siddhi:
+  refs:
+    - ref:
+        name: 'grpcSource'
+        type: 'grpc'
+        properties:
+          receiver.url : grpc://localhost:9806/org.wso2.grpc.EventService/consume
   extensions:
     -
       extension:
@@ -445,6 +451,18 @@ siddhi:
           cacheSize: 10000
           isPersistInDatabase: true
           datasource: GEO_LOCATION_DATA
+   #Enabling GRPC Service with an Extension
+    -
+      extension:
+        name: 'grpc'
+        namespace: 'source'
+        properties:
+          keyStoreFile : ${sys:carbon.home}/resources/security/wso2carbon.jks
+          keyStorePassword : ${sec:wso2.apim.analytics.password}
+          keyStoreAlgorithm : SunX509
+          trustStoreFile : ${sys:carbon.home}/resources/security/client-truststore.jks
+          trustStorePassword : ${sec:wso2.apim.analytics.password}
+          trustStoreAlgorithm : SunX509
 
   # Cluster Configuration
 cluster.config:

--- a/product/distribution/carbon-home/conf/worker/deployment.yaml
+++ b/product/distribution/carbon-home/conf/worker/deployment.yaml
@@ -458,10 +458,10 @@ siddhi:
         namespace: 'source'
         properties:
           keyStoreFile : ${sys:carbon.home}/resources/security/wso2carbon.jks
-          keyStorePassword : ${sec:wso2.apim.analytics.password}
+          keyStorePassword : wso2carbon
           keyStoreAlgorithm : SunX509
           trustStoreFile : ${sys:carbon.home}/resources/security/client-truststore.jks
-          trustStorePassword : ${sec:wso2.apim.analytics.password}
+          trustStorePassword : wso2carbon
           trustStoreAlgorithm : SunX509
 
   # Cluster Configuration


### PR DESCRIPTION
## Purpose
> Enabling gRPC service to be used APIM Analytics 

## Goals
> This change allows WSO2 micro-gateway to publish analytics data using a gRPC service.  
