### PR TITLE
Rename alert configuration siddhi apps

### DIFF
--- a/features/org.wso2.analytics.apim.feature/src/main/resources/siddhi-files/APIM_CONFIGURATION_ALERT.siddhi
+++ b/features/org.wso2.analytics.apim.feature/src/main/resources/siddhi-files/APIM_CONFIGURATION_ALERT.siddhi
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-@App:name("APIM_ALERT_CONFIGURATION")
+@App:name("APIM_CONFIGURATION_ALERT")
 @App:description("Store the alert configurations of each API into two different tables through Store API from APIM.")
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')

--- a/features/org.wso2.analytics.apim.feature/src/main/resources/siddhi-files/APIM_STAKEHOLDER_ALERT.siddhi
+++ b/features/org.wso2.analytics.apim.feature/src/main/resources/siddhi-files/APIM_STAKEHOLDER_ALERT.siddhi
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-@App:name('APIM_ALERT_STAKEHOLDER')
+@App:name('APIM_STAKEHOLDER_ALERT')
 @App:description('Store the alert subscribers information in the database through Stroe API from APIM')
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')


### PR DESCRIPTION
## Purpose
Rename alert configuration siddhi apps, in order to fix error which occurs when configuring alerts from store/publisher without enabling alerts in analytics server
Related PR: https://github.com/wso2/carbon-apimgt/pull/7710