### PR TITLE
Remove getContext method from widgets

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/APIMTopApiCreators/src/APIMTopApiCreatorsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopApiCreators/src/APIMTopApiCreatorsWidget.jsx
@@ -112,18 +112,8 @@ class APIMTopApiCreatorsWidget extends Widget {
         this.handleDataReceived = this.handleDataReceived.bind(this);
         this.handleChange = this.handleChange.bind(this);
         this.loadLocale = this.loadLocale.bind(this);
-        this.getContext = this.getContext.bind(this);
     }
 
-    getContext() {
-        let { username } = super.getCurrentUser();
-        const usernameParts = username.split('@');
-        if (username.includes('@carbon.super')) {
-            return 'NOT(str:contains(CONTEXT,\'/t/\'))';
-        } else {
-            return '(str:contains(CONTEXT,\'/t/' +  usernameParts[usernameParts.length -1] + '\'))';
-        }
-    }
     componentDidMount() {
         const { widgetID } = this.props;
         const locale = languageWithoutRegionCode || language;
@@ -181,8 +171,7 @@ class APIMTopApiCreatorsWidget extends Widget {
         const dataProviderConfigs = cloneDeep(providerConfig);
         dataProviderConfigs.configs.config.queryData.queryName = 'query';
         dataProviderConfigs.configs.config.queryData.queryValues = {
-            '{{limit}}': limit,
-            '{{contextContainsCondition}}': this.getContext(),
+            '{{limit}}': limit
         };
         super.getWidgetChannelManager()
             .subscribeWidget(id, widgetName, this.handleDataReceived, dataProviderConfigs);

--- a/components/org.wso2.analytics.apim.widgets/APIMTopApiUsers/src/APIMTopApiUsersWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopApiUsers/src/APIMTopApiUsersWidget.jsx
@@ -131,7 +131,6 @@ class APIMTopApiUsersWidget extends Widget {
         this.assembleMainQuery = this.assembleMainQuery.bind(this);
         this.loadLocale = this.loadLocale.bind(this);
         this.getUsername = this.getUsername.bind(this);
-        this.getContext = this.getContext.bind(this);
     }
 
     componentDidMount() {
@@ -224,7 +223,6 @@ class APIMTopApiUsersWidget extends Widget {
         const dataProviderConfigs = cloneDeep(providerConfig);
         dataProviderConfigs.configs.config.queryData.queryName = 'apilistquery';
         dataProviderConfigs.configs.config.queryData.queryValues = {
-            '{{contextContainsCondition}}' : this.getContext(),
             '{{createdBy}}' : apiCreatedBy !== 'All' ? 'AND CREATED_BY==\'' + username + '\'' : ''
         };
         super.getWidgetChannelManager()
@@ -242,16 +240,6 @@ class APIMTopApiUsersWidget extends Widget {
             username = username.replace('@carbon.super', '');
         }
         this.setState({ username })
-    }
-
-    getContext() {
-        let { username } = super.getCurrentUser();
-        const usernameParts = username.split('@');
-        if (username.includes('@carbon.super')) {
-            return 'NOT(str:contains(CONTEXT,\'/t/\'))';
-        } else {
-            return '(str:contains(CONTEXT,\'/t/' +  usernameParts[usernameParts.length -1] + '\'))';
-        }
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -1293,7 +1293,7 @@
 
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
         <!--Dashboard-->
-        <carbon.dashboards.version>4.1.2</carbon.dashboards.version>
+        <carbon.dashboards.version>4.1.3</carbon.dashboards.version>
         <carbon.uis.version>1.0.3</carbon.uis.version>
         <maven.exec.plugin.version>1.5.0</maven.exec.plugin.version>
         <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>


### PR DESCRIPTION
## Purpose
Remove the getContext method from widgets

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes