### PR TITLE
Avoid Siddhi warn log stack trace in join processor

### DIFF
--- a/product/distribution/carbon-home/conf/worker/log4j2.xml
+++ b/product/distribution/carbon-home/conf/worker/log4j2.xml
@@ -46,5 +46,9 @@
             <AppenderRef ref="CARBON_CONSOLE"/>
             <AppenderRef ref="CARBON_LOGFILE"/>
         </Root>
+        <Logger name="io.siddhi.core.query.input.stream.join.JoinProcessor" level="ERROR">
+            <AppenderRef ref="CARBON_CONSOLE" />
+            <AppenderRef ref="CARBON_LOGFILE"/>
+        </Logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
## Purpose
 avoid following warn stack trace

` WARN {io.siddhi.core.query.input.stream.join.JoinProcessor} - Performing select clause in databases failed due to 'Error when preparing to execute query: 'SELECT ? AS apiContext, ? AS apiName, ? AS apiVersion, ? AS apiCreator, ? AS apiCreatorTenantDomain, ? AS applicationOwner, ? AS lastAccessTime FROM ApiLastAccessSummary WHERE (((? = ApiLastAccessSummary.apiName ) AND  (? = ApiLastAccessSummary.apiCreatorTenantDomain )) AND  (? = ApiLastAccessSummary.apiCreator )) HAVING ((? >= lastAccessTime )OR lastAccessTime IS NULL )' on 'ApiLastAccessSummary' in query 'Filter events to check latest timestamp' within Siddhi app 'APIM_ACCESS_SUMMARY' hence reverting back to querying only with where clause. io.siddhi.extension.store.rdbms.exception.RDBMSTableException: Error when preparing to execute query: 'SELECT ? AS apiContext, ? AS apiName, ? AS apiVersion, ? AS apiCreator, ? AS apiCreatorTenantDomain, ? AS applicationOwner, ? AS lastAccessTime FROM ApiLastAccessSummary WHERE (((? = ApiLastAccessSummary.apiName ) AND  (? = ApiLastAccessSummary.apiCreatorTenantDomain )) AND  (? = ApiLastAccessSummary.apiCreator )) HAVING ((? >= lastAccessTime )OR lastAccessTime IS NULL )' on 'ApiLastAccessSummary'
	at io.siddhi.extension.store.rdbms.RDBMSEventTable.query(RDBMSEventTable.java:1732)
	at io.siddhi.core.table.record.AbstractQueryableRecordTable.query(AbstractQueryableRecordTable.java:696)
	at io.siddhi.core.query.processor.stream.window.TableWindowProcessor.query(TableWindowProcessor.java:103)
	at io.siddhi.core.query.input.stream.join.JoinProcessor.query(JoinProcessor.java:179)
	at io.siddhi.core.query.input.stream.join.JoinProcessor.process(JoinProcessor.java:108)
	at io.siddhi.core.query.processor.stream.window.LengthBatchWindowProcessor.process(LengthBatchWindowProcessor.java:186)
	at io.siddhi.core.query.processor.stream.window.LengthBatchWindowProcessor.process(LengthBatchWindowProcessor.java:57)
	at io.siddhi.core.query.processor.stream.window.BatchingWindowProcessor.processEventChunk(BatchingWindowProcessor.java:74)
	at io.siddhi.core.query.processor.stream.AbstractStreamProcessor.process(AbstractStreamProcessor.java:132)
	at io.siddhi.core.query.input.stream.join.JoinProcessor.process(JoinProcessor.java:170)
	at io.siddhi.core.query.input.ProcessStreamReceiver.processAndClear(ProcessStreamReceiver.java:183)
	at io.siddhi.core.query.input.ProcessStreamReceiver.process(ProcessStreamReceiver.java:90)
	at io.siddhi.core.query.input.ProcessStreamReceiver.receive(ProcessStreamReceiver.java:116)
	at io.siddhi.core.stream.StreamJunction.sendEvent(StreamJunction.java:176)
	at io.siddhi.core.stream.StreamJunction$Publisher.send(StreamJunction.java:465)
	at io.siddhi.core.query.output.callback.InsertIntoStreamCallback.send(InsertIntoStreamCallback.java:56)
	at io.siddhi.core.query.output.ratelimit.OutputRateLimiter.sendToCallBacks(OutputRateLimiter.java:104)
	at io.siddhi.core.query.output.ratelimit.time.LastGroupByPerTimeOutputRateLimiter.process(LastGroupByPerTimeOutputRateLimiter.java:99)
	at io.siddhi.core.util.Scheduler.sendTimerEvents(Scheduler.java:195)
	at io.siddhi.core.util.Scheduler.access$300(Scheduler.java:48)
	at io.siddhi.core.util.Scheduler$EventCaller.run(Scheduler.java:294)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.h2.jdbc.JdbcSQLException: Column "LASTACCESSTIME" must be in the GROUP BY list; SQL statement:
SELECT ? AS apiContext, ? AS apiName, ? AS apiVersion, ? AS apiCreator, ? AS apiCreatorTenantDomain, ? AS applicationOwner, ? AS lastAccessTime FROM ApiLastAccessSummary WHERE (((? = ApiLastAccessSummary.apiName ) AND  (? = ApiLastAccessSummary.apiCreatorTenantDomain )) AND  (? = ApiLastAccessSummary.apiCreator )) HAVING ((? >= lastAccessTime )OR lastAccessTime IS NULL ) [90016-196]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:345)
	at org.h2.message.DbException.get(DbException.java:179)
	at org.h2.message.DbException.get(DbException.java:155)
	at org.h2.expression.ExpressionColumn.getValue(ExpressionColumn.java:189)
	at org.h2.expression.Comparison.getValue(Comparison.java:237)
	at org.h2.expression.ConditionAndOr.getValue(ConditionAndOr.java:86)
	at org.h2.command.dml.Select.queryGroup(Select.java:364)
	at org.h2.command.dml.Select.queryWithoutCache(Select.java:620)
	at org.h2.command.dml.Query.queryWithoutCacheLazyCheck(Query.java:114)
	at org.h2.command.dml.Query.query(Query.java:371)
	at org.h2.command.dml.Query.query(Query.java:333)
	at org.h2.command.CommandContainer.query(CommandContainer.java:113)
	at org.h2.command.Command.executeQuery(Command.java:201)
	at org.h2.jdbc.JdbcPreparedStatement.executeQuery(JdbcPreparedStatement.java:111)
	at com.zaxxer.hikari.proxy.PreparedStatementProxy.executeQuery(PreparedStatementProxy.java:52)
	at com.zaxxer.hikari.proxy.HikariPreparedStatementProxy.executeQuery(HikariPreparedStatementProxy.java)
	at io.siddhi.extension.store.rdbms.RDBMSEventTable.query(RDBMSEventTable.java:1715)
	... 27 more`
## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.