### PR TITLE
Bump carbon dashboards version for web socket fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1042,7 +1042,7 @@
 
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
         <!--Dashboard-->
-        <carbon.dashboards.version>4.1.7</carbon.dashboards.version>
+        <carbon.dashboards.version>4.1.8</carbon.dashboards.version>
         <carbon.uis.version>1.0.3</carbon.uis.version>
         <maven.exec.plugin.version>1.5.0</maven.exec.plugin.version>
         <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>


### PR DESCRIPTION
## Purpose
Bumping the carbon dashboards version to get the websocket fix

## Goals
Getting the resolution for the websocket getting closed automatically due to a idle client.