### PR TITLE
change tab name 'API Proxy Performance'

### DIFF
--- a/features/org.wso2.analytics.apim.feature/src/main/resources/dashboard/apimpublisher.json
+++ b/features/org.wso2.analytics.apim.feature/src/main/resources/dashboard/apimpublisher.json
@@ -1054,8 +1054,8 @@
           "height": 882
         },
         {
-          "id": "api-proxy-performance",
-          "name": "API Proxy Performance",
+          "id": "api-performance",
+          "name": "API Performance",
           "content": [
             {
               "type": "column",


### PR DESCRIPTION
Currently, we have a tab named **API Proxy Performance**. IMO, Proxy isn't the right word to use here. This PR changes it to **API Performance**. 

@TanyaM Will, we have any issues because of this name change in a migrated environment from 3.0 to 3.1? This is assuming the dashboard will have been already persisted in dashboard DB with the old naming. 