### PR TITLE
Fix DateRangePicker doesn't display the loaded default range

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/DateTimeRangePicker/src/widget/DateTimePicker.jsx
+++ b/components/org.wso2.analytics.apim.widgets/DateTimeRangePicker/src/widget/DateTimePicker.jsx
@@ -88,6 +88,7 @@ class DateTimePicker extends Widget {
       });
       this.setRefreshInterval();
       this.setState({
+        quickRangeGranularityValue: mode,
         granularityMode: mode,
         granularityValue: granularity,
         startTime: startTimeAndGranularity.startTime,
@@ -395,7 +396,7 @@ class DateTimePicker extends Widget {
             granularityValue: granularity,
             startTime: startTimeAndDefaultGranularity.startTime,
             endTime: new Date(),
-            quickRangeGranularityValue: this.getTimeRangeName(range)
+            quickRangeGranularityValue: timeRange
           });
           this.setRefreshInterval();
         } else {


### PR DESCRIPTION
## Purpose
Fix DateRangePicker doesn't display the loaded default range
Fixes https://github.com/wso2/analytics-apim/issues/858