### PR TITLE
Update default time range in api performance tab in publisher dashboard

### DIFF
--- a/features/org.wso2.analytics.apim.feature/src/main/resources/dashboard/apimpublisher.json
+++ b/features/org.wso2.analytics.apim.feature/src/main/resources/dashboard/apimpublisher.json
@@ -1090,7 +1090,7 @@
                           "isGenerated": false,
                           "options": {
                             "header": false,
-                            "defaultValue": "3 Months",
+                            "defaultValue": "1 Month",
                             "availableGranularities": "From Second",
                             "autoSyncInterval": "10"
                           }


### PR DESCRIPTION
## Purpose
If the default time range for the API performance tab is kept at '3 Months', the default granularity will be 'month' and this will result in there being only a single point in the graph. Updating the default time range to '1 Month' will result in default granularity being 'day', and therefore there will be multiple points in then graph.