### PR TITLE
Add blue background to widgets and fix styling issues

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/APIMApiAvailability/src/APIMApiAvailability.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiAvailability/src/APIMApiAvailability.jsx
@@ -37,9 +37,8 @@ export default function APIMApiAvailability(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         dataWrapper: {
             height: '75%',
@@ -51,12 +50,12 @@ export default function APIMApiAvailability(props) {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft: '5%',
         },
         loadingIcon: {
             margin: 'auto',
@@ -68,17 +67,17 @@ export default function APIMApiAvailability(props) {
             justifyContent: 'center',
             height,
         },
-        divWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
-        },
     };
     const availabilityProps = { availableApiData, legendData };
 
     return (
         <Scrollbars style={{ height }}>
-            <div style={{ padding: '5% 5%' }}>
+            <div style={{
+                backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                height,
+                margin: '10px',
+                padding: '20px',
+            }}>
                 <div style={styles.headingWrapper}>
                     <h3 style={{
                         borderBottom: themeName === 'dark' ? '1px solid #fff' : '1px solid #02212f',

--- a/components/org.wso2.analytics.apim.widgets/APIMApiBackendUsageSummary/src/APIMApiBackendUsage.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiBackendUsageSummary/src/APIMApiBackendUsage.jsx
@@ -43,40 +43,31 @@ export default function APIMApiBackendUsage(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         form: {
             display: 'flex',
             flexWrap: 'wrap',
         },
         formControl: {
-            margin: '5%',
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
-        },
-        textField: {
-            margin: '5%',
-            minWidth: 120,
-        },
-        selectEmpty: {
-            marginTop: 10,
         },
         loadingIcon: {
             margin: 'auto',
@@ -92,7 +83,12 @@ export default function APIMApiBackendUsage(props) {
 
     return (
         <Scrollbars style={{ height }}>
-            <div style={{padding: '5% 5%',}}>
+            <div style={{
+                backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                height,
+                margin: '10px',
+                padding: '20px',
+            }}>
                 <div style={styles.headingWrapper}>
                     <h3 style={{
                         borderBottom: themeName === 'dark' ? '1px solid #fff' : '1px solid #02212f',
@@ -119,7 +115,6 @@ export default function APIMApiBackendUsage(props) {
                                 input={<Input name='apiCreatedBy' id='api-createdBy-label-placeholder' />}
                                 displayEmpty
                                 name='apiCreatedBy'
-                                style={styles.selectEmpty}
                             >
                                 <MenuItem value='All'>
                                     <FormattedMessage id='all.menuItem' defaultMessage='All' />
@@ -135,7 +130,7 @@ export default function APIMApiBackendUsage(props) {
                             value={limit}
                             onChange={handleChange}
                             type='number'
-                            style={styles.textField}
+                            style={styles.formControl}
                             InputLabelProps={{
                                 shrink: true,
                             }}

--- a/components/org.wso2.analytics.apim.widgets/APIMApiCreatedAnalytics/src/APIMApiCreatedAnalytics.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiCreatedAnalytics/src/APIMApiCreatedAnalytics.jsx
@@ -40,22 +40,19 @@ export default function APIMApiCreatedAnalytics(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '97%',
+            width: '95%',
         },
         formWrapper: {
-            width: '97%',
-            height: '10%',
-            margin: 'auto',
-            marginTop: '2%',
+            marginBottom: '5%',
         },
         form: {
             display: 'flex',
             flexWrap: 'wrap',
         },
         formControl: {
-            margin: 5,
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
         },
         selectEmpty: {
@@ -85,17 +82,16 @@ export default function APIMApiCreatedAnalytics(props) {
             <div
                 style={{
                     backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
-                    width: '85%',
                     height,
-                    margin: '5% auto',
-                    padding: '10% 5%',
+                    margin: '10px',
+                    padding: '20px',
                 }}
             >
                 <div style={styles.headingWrapper}>
                     <div style={{
                         borderBottom: themeName === 'dark' ? '1px solid #fff' : '1px solid #02212f',
-                        width: '40%',
-                        paddingBottom: '15px',
+                        paddingBottom: '10px',
+                        margin: 'auto',
                         textAlign: 'left',
                         fontWeight: 'normal',
                         letterSpacing: 1.5,

--- a/components/org.wso2.analytics.apim.widgets/APIMApiCreatedAnalytics/src/APIMApiCreatedData.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiCreatedAnalytics/src/APIMApiCreatedData.jsx
@@ -45,6 +45,17 @@ export default function APIMApiCreatedData(props) {
             width: '97%',
             margin: 'auto',
         },
+        paperWrapper: {
+            height: '75%',
+        },
+        paper: {
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
+            width: '75%',
+            padding: '4%',
+            border: '1.5px solid',
+            marginLeft:'5%',
+        },
         chartWrapper: {
             width: '100%',
             height: '70%',
@@ -219,16 +230,10 @@ export default function APIMApiCreatedData(props) {
         );
     } else {
         return (
-            <div style={styles.dataWrapper}>
+            <div style={styles.paperWrapper}>
                 <Paper
                     elevation={1}
-                    style={{
-                        padding: '4%',
-                        border: '1px solid #fff',
-                        height: '10%',
-                        marginTop: '5%',
-                    }}
-                >
+                    style={styles.paper}>
                     <Typography variant='h5' component='h3'>
                         <FormattedMessage id='nodata.error.heading' defaultMessage='No Data Available !' />
                     </Typography>

--- a/components/org.wso2.analytics.apim.widgets/APIMApiLastAccessSummary/src/APIMApiLastAccess.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiLastAccessSummary/src/APIMApiLastAccess.jsx
@@ -43,40 +43,31 @@ export default function APIMApiLastAccess(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         form: {
             display: 'flex',
             flexWrap: 'wrap',
         },
         formControl: {
-            margin: '5%',
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
-        },
-        textField: {
-            margin: '5%',
-            minWidth: 120,
-        },
-        selectEmpty: {
-            marginTop: 10,
         },
         loadingIcon: {
             margin: 'auto',
@@ -95,7 +86,10 @@ export default function APIMApiLastAccess(props) {
             style={{ height }}
         >
             <div style={{
-                padding: '5% 5%',
+                backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                height,
+                margin: '10px',
+                padding: '20px',
             }}
             >
                 <div style={styles.headingWrapper}>
@@ -124,7 +118,6 @@ export default function APIMApiLastAccess(props) {
                                 input={<Input name='apiCreatedBy' id='api-createdBy-label-placeholder' />}
                                 displayEmpty
                                 name='apiCreatedBy'
-                                style={styles.selectEmpty}
                             >
                                 <MenuItem value='All'>
                                     <FormattedMessage id='all.menuItem' defaultMessage='All' />
@@ -140,7 +133,7 @@ export default function APIMApiLastAccess(props) {
                             value={limit}
                             onChange={handleChange}
                             type='number'
-                            style={styles.textField}
+                            style={styles.formControl}
                             InputLabelProps={{
                                 shrink: true,
                             }}

--- a/components/org.wso2.analytics.apim.widgets/APIMApiLatencyTime/src/APIMApiLatency.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiLatencyTime/src/APIMApiLatency.jsx
@@ -51,25 +51,20 @@ export default function APIMApiLatency(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '97%',
+            width: '95%',
         },
         formWrapper: {
-            width: '90%',
-            height: '20%',
-            margin: 'auto',
+            marginBottom:'5%',
         },
         form: {
             display: 'flex',
             flexWrap: 'wrap',
         },
         formControl: {
-            margin: '5%',
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
-        },
-        selectEmpty: {
-            marginTop: 10,
         },
         dataWrapper: {
             height: '70%',
@@ -80,12 +75,12 @@ export default function APIMApiLatency(props) {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         loadingIcon: {
             margin: 'auto',
@@ -115,14 +110,18 @@ export default function APIMApiLatency(props) {
         >
             <div
                 style={{
-                    padding: '5% 5%',
+                    backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                    height,
+                    margin: '10px',
+                    padding: '20px',
                 }}
             >
                 <div style={styles.headingWrapper}>
                     <div style={{
                         borderBottom: themeName === 'dark' ? '1px solid #fff' : '1px solid #02212f',
-                        width: '40%',
-                        paddingBottom: '15px',
+                        paddingBottom: '10px',
+                        margin: 'auto',
+                        marginTop: 0,
                         textAlign: 'left',
                         fontWeight: 'normal',
                         letterSpacing: 1.5,
@@ -143,7 +142,6 @@ export default function APIMApiLatency(props) {
                                 input={<Input name='apiCreatedBy' id='api-createdBy-label-placeholder' />}
                                 displayEmpty
                                 name='apiCreatedBy'
-                                style={styles.selectEmpty}
                             >
                                 <MenuItem value='All'>
                                     <FormattedMessage id='all.menuItem' defaultMessage='All' />
@@ -163,7 +161,6 @@ export default function APIMApiLatency(props) {
                                 input={<Input name='apiSelected' id='apiSelected-label-placeholder' />}
                                 displayEmpty
                                 name='apiSelected'
-                                style={styles.selectEmpty}
                             >
                                 {
                                     apilist.map(option => (
@@ -184,7 +181,6 @@ export default function APIMApiLatency(props) {
                                 input={<Input name='apiVersion' id='apiVersion-label-placeholder' />}
                                 displayEmpty
                                 name='apiVersion'
-                                style={styles.selectEmpty}
                             >
                                 {
                                     versionlist.map(option => (

--- a/components/org.wso2.analytics.apim.widgets/APIMApiRatings/src/APIMApiRatings.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiRatings/src/APIMApiRatings.jsx
@@ -37,9 +37,8 @@ export default function APIMApiRatings(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         dataWrapper: {
             height: '75%',
@@ -51,12 +50,12 @@ export default function APIMApiRatings(props) {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         loadingIcon: {
             margin: 'auto',
@@ -68,16 +67,17 @@ export default function APIMApiRatings(props) {
             justifyContent: 'center',
             height,
         },
-        divWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
-        },
     };
 
     return (
         <Scrollbars style={{ height }}>
-            <div style={{ padding: '5% 5%' }}>
+            <div style={{
+                backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                height,
+                margin: '10px',
+                padding: '20px',
+            }}
+            >
                 <div style={styles.headingWrapper}>
                     <h3 style={{
                         borderBottom: themeName === 'dark' ? '1px solid #fff' : '1px solid #02212f',

--- a/components/org.wso2.analytics.apim.widgets/APIMApiResourceUsageSummary/src/APIMApiResourceUsage.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiResourceUsageSummary/src/APIMApiResourceUsage.jsx
@@ -43,40 +43,31 @@ export default function APIMApiResourceUsage(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         form: {
             display: 'flex',
             flexWrap: 'wrap',
         },
         formControl: {
-            margin: '5%',
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
-        },
-        textField: {
-            margin: '5%',
-            minWidth: 120,
-        },
-        selectEmpty: {
-            marginTop: 10,
         },
         loadingIcon: {
             margin: 'auto',
@@ -95,7 +86,10 @@ export default function APIMApiResourceUsage(props) {
             style={{ height }}
         >
             <div style={{
-                padding: '5% 5%',
+                backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                height,
+                margin: '10px',
+                padding: '20px',
             }}
             >
                 <div style={styles.headingWrapper}>
@@ -124,7 +118,6 @@ export default function APIMApiResourceUsage(props) {
                                 input={<Input name='apiCreatedBy' id='api-createdBy-label-placeholder' />}
                                 displayEmpty
                                 name='apiCreatedBy'
-                                style={styles.selectEmpty}
                             >
                                 <MenuItem value='All'>
                                     <FormattedMessage id='all.menuItem' defaultMessage='All' />
@@ -140,7 +133,7 @@ export default function APIMApiResourceUsage(props) {
                             value={limit}
                             onChange={handleChange}
                             type='number'
-                            style={styles.textField}
+                            style={styles.formControl}
                             InputLabelProps={{
                                 shrink: true,
                             }}

--- a/components/org.wso2.analytics.apim.widgets/APIMApiVersionUsageSummary/src/APIMApiVersionUsage.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiVersionUsageSummary/src/APIMApiVersionUsage.jsx
@@ -43,40 +43,31 @@ export default function APIMApiVersionUsage(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         form: {
             display: 'flex',
             flexWrap: 'wrap',
         },
         formControl: {
-            margin: '5%',
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
-        },
-        textField: {
-            margin: '5%',
-            minWidth: 120,
-        },
-        selectEmpty: {
-            marginTop: 10,
         },
         loadingIcon: {
             margin: 'auto',
@@ -95,7 +86,10 @@ export default function APIMApiVersionUsage(props) {
             style={{ height }}
         >
             <div style={{
-                padding: '5% 5%',
+                backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                height,
+                margin: '10px',
+                padding: '20px',
             }}
             >
                 <div style={styles.headingWrapper}>
@@ -124,7 +118,6 @@ export default function APIMApiVersionUsage(props) {
                                 input={<Input name='apiCreatedBy' id='api-createdBy-label-placeholder' />}
                                 displayEmpty
                                 name='apiCreatedBy'
-                                style={styles.selectEmpty}
                             >
                                 <MenuItem value='All'>
                                     <FormattedMessage id='all.menuItem' defaultMessage='All' />
@@ -140,7 +133,7 @@ export default function APIMApiVersionUsage(props) {
                             value={limit}
                             onChange={handleChange}
                             type='number'
-                            style={styles.textField}
+                            style={styles.formControl}
                             InputLabelProps={{
                                 shrink: true,
                             }}

--- a/components/org.wso2.analytics.apim.widgets/APIMAppApiUsage/src/APIMAppApiUsage.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAppApiUsage/src/APIMAppApiUsage.jsx
@@ -46,42 +46,40 @@ export default function APIMAppApiUsage(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
+        },
+        form: {
+            display: 'flex',
+            flexWrap: 'wrap',
         },
         formWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
-        },
-        gridWrapper: {
-            marginLeft: '5%',
+            marginBottom: '5%',
         },
         formControl: {
-            marginTop: '5%',
             marginLeft: '5%',
+            marginTop: '5%',
+            minWidth: 120,
         },
         textField: {
-            marginTop: 0,
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
             width: '30%',
         },
         select: {
-            paddingTop: 5,
-            marginTop: 10,
-            minWidth: 300,
+            minWidth: width * 0.3 < 200 ? 150 : 200,
         },
         inProgress: {
             display: 'flex',
@@ -90,7 +88,10 @@ export default function APIMAppApiUsage(props) {
             height,
         },
         mainDiv: {
-            padding: '5% 5%',
+            backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+            height,
+            margin: '10px',
+            padding: '20px',
         },
         statDiv: {
             display: 'flex',
@@ -177,20 +178,18 @@ export default function APIMAppApiUsage(props) {
                                 }
                             </Select>
                         </FormControl>
-                        <FormControl style={styles.formControl}>
-                            <TextField
-                                id='limit-number'
-                                label={<FormattedMessage id='limit' defaultMessage='Limit :' />}
-                                value={limit}
-                                onChange={handleLimitChange}
-                                type='number'
-                                style={styles.textField}
-                                InputLabelProps={{
-                                    shrink: true,
-                                }}
-                                margin='normal'
-                            />
-                        </FormControl>
+                        <TextField
+                            id='limit-number'
+                            label={<FormattedMessage id='limit' defaultMessage='Limit :' />}
+                            value={limit}
+                            onChange={handleLimitChange}
+                            type='number'
+                            style={styles.textField}
+                            InputLabelProps={{
+                                shrink: true,
+                            }}
+                            margin='normal'
+                        />
                     </form>
                 </div>
                 { inProgress ? (

--- a/components/org.wso2.analytics.apim.widgets/APIMAppCreatedAnalytics/src/APIMAppCreatedAnalytics.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAppCreatedAnalytics/src/APIMAppCreatedAnalytics.jsx
@@ -42,22 +42,19 @@ export default function APIMAppCreatedAnalytics(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '97%',
+            width: '95%',
         },
         formWrapper: {
-            width: '97%',
-            height: '10%',
-            margin: 'auto',
-            marginTop: '2%',
+            marginBottom: '5%',
         },
         form: {
             display: 'flex',
             flexWrap: 'wrap',
         },
         formControl: {
-            margin: 5,
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
         },
         selectEmpty: {
@@ -88,17 +85,17 @@ export default function APIMAppCreatedAnalytics(props) {
         <Scrollbars style={{ height }}>
             <div
                 style={{
-                    background: themeName === 'dark' ? '#0e1e33' : '#fff',
-                    width: '85%',
-                    padding: '5% 5%',
-                    margin: '1.5% auto',
+                    backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                    height,
+                    margin: '10px',
+                    padding: '20px',
                 }}
             >
                 <div style={styles.headingWrapper}>
                     <div style={{
                         borderBottom: themeName === 'dark' ? '1px solid #fff' : '1px solid #02212f',
-                        width: '40%',
-                        paddingBottom: '15px',
+                        paddingBottom: '10px',
+                        margin: 'auto',
                         textAlign: 'left',
                         fontWeight: 'normal',
                         letterSpacing: 1.5,

--- a/components/org.wso2.analytics.apim.widgets/APIMAppCreatedAnalytics/src/APIMAppCreatedData.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAppCreatedAnalytics/src/APIMAppCreatedData.jsx
@@ -45,6 +45,17 @@ export default function APIMAppCreatedData(props) {
             width: '97%',
             margin: 'auto',
         },
+        paperWrapper: {
+            height: '75%',
+        },
+        paper: {
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
+            width: '75%',
+            padding: '4%',
+            border: '1.5px solid',
+            marginLeft:'5%',
+        },
         chartWrapper: {
             width: '100%',
             height: '70%',
@@ -219,16 +230,10 @@ export default function APIMAppCreatedData(props) {
         );
     } else {
         return (
-            <div style={styles.dataWrapper}>
+            <div style={styles.paperWrapper}>
                 <Paper
                     elevation={1}
-                    style={{
-                        padding: '4%',
-                        border: '1px solid #fff',
-                        height: '10%',
-                        marginTop: '5%',
-                    }}
-                >
+                    style={styles.paper}>
                     <Typography variant='h5' component='h3'>
                         <FormattedMessage id='nodata.error.heading' defaultMessage='No Data Available !' />
                     </Typography>

--- a/components/org.wso2.analytics.apim.widgets/APIMAppResourceUsage/src/APIMAppResourceUsage.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAppResourceUsage/src/APIMAppResourceUsage.jsx
@@ -39,33 +39,33 @@ import CustomTable from './CustomTable';
  */
 export default function APIMAppResourceUsage(props) {
     const {
-        themeName, height, limit, applicationSelected, usageData, applicationList, applicationSelectedHandleChange,
+        themeName, height, width, limit, applicationSelected, usageData, applicationList, applicationSelectedHandleChange,
         handleLimitChange, inProgress,
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
+        },
+        form: {
+            display: 'flex',
+            flexWrap: 'wrap',
         },
         formWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         formControl: {
             marginTop: '5%',
             marginLeft: '5%',
         },
         textField: {
-            marginTop: 0,
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
             width: '30%',
         },
         select: {
-            paddingTop: 5,
-            marginTop: 10,
-            minWidth: 300,
+            minWidth: width * 0.3 < 200 ? 150 : 200,
         },
         table: {
             paddingTop: 35,
@@ -73,7 +73,10 @@ export default function APIMAppResourceUsage(props) {
             width: '90%',
         },
         div: {
-            padding: '5% 5%',
+            backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+            height,
+            margin: '10px',
+            padding: '20px',
         },
         h3: {
             borderBottom: themeName === 'dark' ? '1px solid #fff' : '1px solid #02212f',
@@ -88,12 +91,12 @@ export default function APIMAppResourceUsage(props) {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         inProgress: {
             display: 'flex',
@@ -147,23 +150,21 @@ export default function APIMAppResourceUsage(props) {
                                 }
                             </Select>
                         </FormControl>
-                        <FormControl style={styles.formControl}>
-                            <TextField
-                                id='limit-number'
-                                label={<FormattedMessage id='limit' defaultMessage='Limit :' />}
-                                value={limit}
-                                onChange={handleLimitChange}
-                                type='number'
-                                style={styles.textField}
-                                InputLabelProps={{
-                                    shrink: true,
-                                }}
-                                margin='normal'
-                            />
-                        </FormControl>
+                        <TextField
+                            id='limit-number'
+                            label={<FormattedMessage id='limit' defaultMessage='Limit :' />}
+                            value={limit}
+                            onChange={handleLimitChange}
+                            type='number'
+                            style={styles.textField}
+                            InputLabelProps={{
+                                shrink: true,
+                            }}
+                            margin='normal'
+                        />
                     </form>
                 </div>
-                <div style={styles.table}>
+                <div>
                     { inProgress ? (
                         <div style={styles.inProgress}>
                             <CircularProgress />
@@ -171,10 +172,12 @@ export default function APIMAppResourceUsage(props) {
                     ) : (
                         <div>
                             { usageData && usageData.length > 0 ? (
-                                <CustomTable
-                                    data={usageData}
-                                    inProgress={inProgress}
-                                />
+                                <div style={styles.table}>
+                                    <CustomTable
+                                        data={usageData}
+                                        inProgress={inProgress}
+                                    />
+                                </div>
                             ) : (
                                 <div style={styles.paperWrapper}>
                                     <Paper

--- a/components/org.wso2.analytics.apim.widgets/APIMAppResourceUsage/src/APIMAppResourceUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAppResourceUsage/src/APIMAppResourceUsageWidget.jsx
@@ -442,7 +442,7 @@ class APIMAppResourceUsageWidget extends Widget {
      */
     render() {
         const {
-            localeMessages, faultyProviderConfig, height, limit, applicationSelected, usageData, applicationList,
+            localeMessages, faultyProviderConfig, height, width, limit, applicationSelected, usageData, applicationList,
             inProgress, proxyError,
         } = this.state;
         const {
@@ -453,6 +453,7 @@ class APIMAppResourceUsageWidget extends Widget {
         const resourceUsageProps = {
             themeName,
             height,
+            width,
             limit,
             applicationList,
             applicationSelected,

--- a/components/org.wso2.analytics.apim.widgets/APIMFaultyPerApp/src/APIMFaultyPerApp.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMFaultyPerApp/src/APIMFaultyPerApp.jsx
@@ -39,33 +39,33 @@ import CustomTable from './CustomTable';
  */
 export default function APIMFaultyPerApp(props) {
     const {
-        themeName, height, limit, applicationSelected, usageData, applicationList,
+        themeName, height, width, limit, applicationSelected, usageData, applicationList,
         applicationSelectedHandleChange, handleLimitChange, inProgress,
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
+        },
+        form: {
+            display: 'flex',
+            flexWrap: 'wrap',
         },
         formWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         formControl: {
             marginTop: '5%',
             marginLeft: '5%',
         },
         textField: {
-            marginTop: 0,
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
             width: '30%',
         },
         select: {
-            paddingTop: 5,
-            marginTop: 10,
-            minWidth: 300,
+            minWidth: width * 0.3 < 200 ? 150 : 200,
         },
         table: {
             paddingTop: 35,
@@ -85,12 +85,12 @@ export default function APIMFaultyPerApp(props) {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         inProgress: {
             display: 'flex',
@@ -102,7 +102,12 @@ export default function APIMFaultyPerApp(props) {
 
     return (
         <Scrollbars style={{ height }}>
-            <div style={{ padding: '5% 5%' }}>
+            <div style={{
+                backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                height,
+                margin: '10px',
+                padding: '20px',
+            }}>
                 <div style={styles.headingWrapper}>
                     <h3 style={styles.h3}>
                         <FormattedMessage id='widget.heading' defaultMessage='FAULTY INVOCATIONS PER APPLICATION' />
@@ -141,23 +146,21 @@ export default function APIMFaultyPerApp(props) {
                                 }
                             </Select>
                         </FormControl>
-                        <FormControl style={styles.formControl}>
-                            <TextField
-                                id='limit-number'
-                                label={<FormattedMessage id='limit' defaultMessage='Limit :' />}
-                                value={limit}
-                                onChange={handleLimitChange}
-                                type='number'
-                                style={styles.textField}
-                                InputLabelProps={{
-                                    shrink: true,
-                                }}
-                                margin='normal'
-                            />
-                        </FormControl>
+                        <TextField
+                            id='limit-number'
+                            label={<FormattedMessage id='limit' defaultMessage='Limit :' />}
+                            value={limit}
+                            onChange={handleLimitChange}
+                            type='number'
+                            style={styles.textField}
+                            InputLabelProps={{
+                                shrink: true,
+                            }}
+                            margin='normal'
+                        />
                     </form>
                 </div>
-                <div style={styles.table}>
+                <div>
                     { inProgress ? (
                         <div style={styles.inProgress}>
                             <CircularProgress />
@@ -165,10 +168,12 @@ export default function APIMFaultyPerApp(props) {
                         ) : (
                         <div>
                             { usageData.length > 0 ? (
-                                <CustomTable
-                                    data={usageData}
-                                    inProgress={inProgress}
-                                />
+                                <div style={styles.table}>
+                                    <CustomTable
+                                        data={usageData}
+                                        inProgress={inProgress}
+                                   />
+                                </div>
                             ) : (
                                 <div style={styles.paperWrapper}>
                                     <Paper

--- a/components/org.wso2.analytics.apim.widgets/APIMFaultyPerApp/src/APIMFaultyPerAppWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMFaultyPerApp/src/APIMFaultyPerAppWidget.jsx
@@ -438,7 +438,7 @@ class APIMFaultyPerAppWidget extends Widget {
      */
     render() {
         const {
-            localeMessages, faultyProviderConfig, height, limit, applicationSelected, usageData, applicationList,
+            localeMessages, faultyProviderConfig, height, width, limit, applicationSelected, usageData, applicationList,
             inProgress, proxyError,
         } = this.state;
         const {
@@ -449,6 +449,7 @@ class APIMFaultyPerAppWidget extends Widget {
         const faultyUsageProps = {
             themeName,
             height,
+            width,
             limit,
             applicationList,
             applicationSelected,

--- a/components/org.wso2.analytics.apim.widgets/APIMGeoBasedInvocations/src/APIMGeoInvocations.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMGeoBasedInvocations/src/APIMGeoInvocations.jsx
@@ -46,12 +46,12 @@ export default function APIMGeoInvocations(props) {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         dataWrapper: {
             height: '80%',
@@ -67,26 +67,20 @@ export default function APIMGeoInvocations(props) {
             height,
         },
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '100%',
+            width: '95%',
         },
         formWrapper: {
-            width: '100%',
-            height: '10%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         form: {
             display: 'flex',
             flexWrap: 'wrap',
         },
         formControl: {
-            margin: '2%',
-            marginLeft: 0,
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
-        },
-        selectEmpty: {
-            marginTop: 10,
         },
     };
 
@@ -96,7 +90,10 @@ export default function APIMGeoInvocations(props) {
         >
             <div
                 style={{
-                    padding: '5%',
+                    backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                    height,
+                    margin: '10px',
+                    padding: '20px',
                 }}
             >
                 <div style={styles.headingWrapper}>
@@ -125,7 +122,6 @@ export default function APIMGeoInvocations(props) {
                                 input={<Input name='apiCreatedBy' id='api-createdBy-label-placeholder' />}
                                 displayEmpty
                                 name='apiCreatedBy'
-                                style={styles.selectEmpty}
                             >
                                 <MenuItem value='All'>
                                     <FormattedMessage id='all.menuItem' defaultMessage='All' />
@@ -145,7 +141,6 @@ export default function APIMGeoInvocations(props) {
                                 input={<Input name='apiSelected' id='apiSelected-label-placeholder' />}
                                 displayEmpty
                                 name='apiSelected'
-                                style={styles.selectEmpty}
                             >
                                 {
                                     apilist.map(option => (
@@ -166,7 +161,6 @@ export default function APIMGeoInvocations(props) {
                                 input={<Input name='apiVersion' id='apiVersion-label-placeholder' />}
                                 displayEmpty
                                 name='apiVersion'
-                                style={styles.selectEmpty}
                             >
                                 {
                                     versionlist.map(option => (

--- a/components/org.wso2.analytics.apim.widgets/APIMOverallApiUsage/src/APIMOverallApiUsage.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMOverallApiUsage/src/APIMOverallApiUsage.jsx
@@ -45,40 +45,31 @@ export default function APIMOverallApiUsage(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         form: {
             display: 'flex',
             flexWrap: 'wrap',
         },
         formControl: {
-            margin: '5%',
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
-        },
-        textField: {
-            margin: '5%',
-            minWidth: 120,
-        },
-        selectEmpty: {
-            marginTop: 10,
         },
         dataWrapper: {
             height: '80%',
@@ -106,7 +97,12 @@ export default function APIMOverallApiUsage(props) {
 
     return (
         <Scrollbars style={{ height: '100%' }}>
-            <div style={{ padding: '5% 5%' }}>
+            <div style={{
+                backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                height,
+                margin: '10px',
+                padding: '20px',
+            }}>
                 <div style={styles.headingWrapper}>
                     <div style={{
                         borderBottom: themeName === 'dark' ? '1px solid #fff' : '1px solid #02212f',
@@ -133,7 +129,6 @@ export default function APIMOverallApiUsage(props) {
                                 input={<Input name='api-createdBy' id='api-createdBy-label-placeholder' />}
                                 displayEmpty
                                 name='apiCreatedBy'
-                                style={styles.selectEmpty}
                             >
                                 <MenuItem value='all'>
                                     <FormattedMessage id='all.menuItem' defaultMessage='All' />
@@ -149,7 +144,7 @@ export default function APIMOverallApiUsage(props) {
                             value={limit}
                             onChange={limitHandleChange}
                             type='number'
-                            style={styles.textField}
+                            style={styles.formControl}
                             InputLabelProps={{
                                 shrink: true,
                             }}

--- a/components/org.wso2.analytics.apim.widgets/APIMRegisteredAppUsers/src/APIMRegisteredAppUsers.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMRegisteredAppUsers/src/APIMRegisteredAppUsers.jsx
@@ -39,23 +39,26 @@ export default function APIMRegisteredAppUsers(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
+            marginTop:'5%',
         },
         contentDiv: {
-            padding: '5% 5%',
+            backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+            height,
+            margin: '10px',
+            padding: '20px',
         },
         statDiv: {
             display: 'flex',

--- a/components/org.wso2.analytics.apim.widgets/APIMSignupsAnalytics/src/APIMSignupsAnalytics.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMSignupsAnalytics/src/APIMSignupsAnalytics.jsx
@@ -35,10 +35,8 @@ export default function APIMSignupsAnalytics(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '97%',
-            marginBottom: '5%',
+            width: '95%',
         },
         loadingIcon: {
             margin: 'auto',
@@ -60,17 +58,17 @@ export default function APIMSignupsAnalytics(props) {
         >
             <div
                 style={{
-                    background: themeName === 'dark' ? '#0e1e33' : '#fff',
-                    width: '85%',
-                    padding: '5% 5%',
-                    margin: '1.5% auto',
+                    backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                    height,
+                    margin: '10px',
+                    padding: '20px',
                 }}
             >
                 <div style={styles.headingWrapper}>
                     <div style={{
                         borderBottom: themeName === 'dark' ? '1px solid #fff' : '1px solid #02212f',
-                        width: '50%',
-                        paddingBottom: '15px',
+                        paddingBottom: '10px',
+                        margin: 'auto',
                         textAlign: 'left',
                         fontWeight: 'normal',
                         letterSpacing: 1.5,

--- a/components/org.wso2.analytics.apim.widgets/APIMSignupsAnalytics/src/APIMSignupsData.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMSignupsAnalytics/src/APIMSignupsData.jsx
@@ -40,6 +40,18 @@ export default function APIMSignupsData(props) {
         themeName, chartData, tableData, xAxisTicks, maxCount,
     } = props;
     const styles = {
+        paperWrapper: {
+            height: '75%',
+        },
+        paper: {
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
+            width: '75%',
+            padding: '4%',
+            border: '1.5px solid',
+            marginLeft: '5%',
+            marginTop: '5%',
+        },
         dataWrapper: {
             height: '78%',
             width: '97%',
@@ -219,16 +231,10 @@ export default function APIMSignupsData(props) {
         );
     } else {
         return (
-            <div style={styles.dataWrapper}>
+            <div style={styles.paperWrapper}>
                 <Paper
                     elevation={1}
-                    style={{
-                        padding: '4%',
-                        border: '1px solid #fff',
-                        height: '10%',
-                        marginTop: '5%',
-                    }}
-                >
+                    style={styles.paper}>
                     <Typography variant='h5' component='h3'>
                         <FormattedMessage id='nodata.error.heading' defaultMessage='No Data Available !' />
                     </Typography>

--- a/components/org.wso2.analytics.apim.widgets/APIMSubscriptionsAnalytics/src/APIMSubscriptionsAnalytics.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMSubscriptionsAnalytics/src/APIMSubscriptionsAnalytics.jsx
@@ -41,22 +41,19 @@ export default function APIMSubscriptionsAnalytics(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '97%',
+            width: '95%',
         },
         formWrapper: {
-            width: '97%',
-            height: '10%',
-            margin: 'auto',
-            marginTop: '2%',
+            marginBottom: '5%',
         },
         form: {
             display: 'flex',
             flexWrap: 'wrap',
         },
         formControl: {
-            margin: 5,
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
         },
         selectEmpty: {
@@ -83,17 +80,16 @@ export default function APIMSubscriptionsAnalytics(props) {
             <div
                 style={{
                     backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
-                    width: '85%',
                     height,
-                    margin: '5% auto',
-                    padding: '5%',
+                    margin: '10px',
+                    padding: '20px',
                 }}
             >
                 <div style={styles.headingWrapper}>
                     <div style={{
                         borderBottom: themeName === 'dark' ? '1px solid #fff' : '1px solid #02212f',
-                        width: '40%',
-                        paddingBottom: '15px',
+                        paddingBottom: '10px',
+                        margin: 'auto',
                         textAlign: 'left',
                         fontWeight: 'normal',
                         letterSpacing: 1.5,

--- a/components/org.wso2.analytics.apim.widgets/APIMSubscriptionsAnalytics/src/APIMSubscriptionsData.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMSubscriptionsAnalytics/src/APIMSubscriptionsData.jsx
@@ -40,6 +40,17 @@ export default function APIMSubscriptionsData(props) {
         themeName, chartData, tableData, xAxisTicks, maxCount,
     } = props;
     const styles = {
+        paperWrapper: {
+            height: '75%',
+        },
+        paper: {
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
+            width: '75%',
+            padding: '4%',
+            border: '1.5px solid',
+            marginLeft: '5%',
+        },
         dataWrapper: {
             height: '78%',
             width: '97%',
@@ -219,16 +230,8 @@ export default function APIMSubscriptionsData(props) {
         );
     } else {
         return (
-            <div style={styles.dataWrapper}>
-                <Paper
-                    elevation={1}
-                    style={{
-                        padding: '4%',
-                        border: '1px solid #fff',
-                        height: '10%',
-                        marginTop: '5%',
-                    }}
-                >
+            <div style={styles.paperWrapper}>
+                <Paper  style={styles.paper}>
                     <Typography variant='h5' component='h3'>
                         <FormattedMessage id='nodata.error.heading' defaultMessage='No Data Available !' />
                     </Typography>

--- a/components/org.wso2.analytics.apim.widgets/APIMTopApiCreators/src/APIMTopApiCreators.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopApiCreators/src/APIMTopApiCreators.jsx
@@ -59,25 +59,22 @@ export default function APIMTopApiCreators(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft: '5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '15%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         form: {
             width: '30%',
@@ -112,9 +109,9 @@ export default function APIMTopApiCreators(props) {
             >
                 <div style={{
                     backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
-                    width: '80%',
-                    margin: '5% auto',
-                    padding: '10% 5%',
+                    height,
+                    margin: '10px',
+                    padding: '20px',
                 }}
                 >
                     <div style={styles.headingWrapper}>

--- a/components/org.wso2.analytics.apim.widgets/APIMTopApiUsers/src/APIMTopApiUsers.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopApiUsers/src/APIMTopApiUsers.jsx
@@ -44,41 +44,31 @@ export default function APIMTopApiUsers(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         form: {
             display: 'flex',
             flexWrap: 'wrap',
         },
         formControl: {
-            margin: '5%',
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
-        },
-        textField: {
-            margin: '5%',
-            marginTop: 0,
-            minWidth: 120,
-        },
-        selectEmpty: {
-            marginTop: 10,
         },
         loadingIcon: {
             margin: 'auto',
@@ -97,7 +87,10 @@ export default function APIMTopApiUsers(props) {
             style={{ height }}
         >
             <div style={{
-                padding: '5% 5%',
+                backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                height,
+                margin: '10px',
+                padding: '20px',
             }}
             >
                 <div style={styles.headingWrapper}>
@@ -188,7 +181,7 @@ export default function APIMTopApiUsers(props) {
                             value={limit}
                             onChange={handleLimitChange}
                             type='number'
-                            style={styles.textField}
+                            style={styles.formControl}
                             InputLabelProps={{
                                 shrink: true,
                             }}

--- a/components/org.wso2.analytics.apim.widgets/APIMTopAppCreators/src/APIMTopAppCreators.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopAppCreators/src/APIMTopAppCreators.jsx
@@ -59,25 +59,22 @@ export default function APIMTopAppCreators(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '15%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         form: {
             width: '30%',
@@ -112,9 +109,9 @@ export default function APIMTopAppCreators(props) {
             >
                 <div style={{
                     backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
-                    width: '80%',
-                    margin: '5% auto',
-                    padding: '10% 5%',
+                    height,
+                    margin: '10px',
+                    padding: '20px',
                 }}
                 >
                     <div style={styles.headingWrapper}>

--- a/components/org.wso2.analytics.apim.widgets/APIMTopAppUsers/src/APIMTopAppUsers.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopAppUsers/src/APIMTopAppUsers.jsx
@@ -46,42 +46,42 @@ export default function APIMTopAppUsers(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         gridWrapper: {
             marginLeft: '5%',
+        },
+        form: {
+            display: 'flex',
+            flexWrap: 'wrap',
         },
         formControl: {
             marginTop: '5%',
             marginLeft: '5%',
         },
         textField: {
-            marginTop: 0,
+            marginTop: '5%',
+            marginLeft: '5%',
             minWidth: 120,
             width: '30%',
         },
         select: {
-            paddingTop: 5,
-            marginTop: 10,
-            minWidth: 300,
+            minWidth: width * 0.3 < 200 ? 150 : 200,
         },
         inProgress: {
             display: 'flex',
@@ -132,7 +132,12 @@ export default function APIMTopAppUsers(props) {
 
     return (
         <Scrollbars style={{ height }}>
-            <div style={{ padding: '5% 5%' }}>
+            <div style={{
+                backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                height,
+                margin: '10px',
+                padding: '20px',
+            }}>
                 <div style={styles.headingWrapper}>
                     <h3 style={styles.h3}>
                         <FormattedMessage id='widget.heading' defaultMessage='TOP APPLICATION USERS' />
@@ -174,20 +179,18 @@ export default function APIMTopAppUsers(props) {
                                 }
                             </Select>
                         </FormControl>
-                        <FormControl style={styles.formControl}>
-                            <TextField
-                                id='limit-number'
-                                label={<FormattedMessage id='limit' defaultMessage='Limit :' />}
-                                value={limit}
-                                onChange={handleLimitChange}
-                                type='number'
-                                style={styles.textField}
-                                InputLabelProps={{
-                                    shrink: true,
-                                }}
-                                margin='normal'
-                            />
-                        </FormControl>
+                        <TextField
+                            id='limit-number'
+                            label={<FormattedMessage id='limit' defaultMessage='Limit :' />}
+                            value={limit}
+                            onChange={handleLimitChange}
+                            type='number'
+                            style={styles.textField}
+                            InputLabelProps={{
+                                shrink: true,
+                            }}
+                            margin='normal'
+                        />
                     </form>
                 </div>
                 { inProgress ? (

--- a/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/APIMTopFaultyApis.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/APIMTopFaultyApis.jsx
@@ -59,37 +59,31 @@ export default function APIMTopFaultyApis(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '15%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         form: {
-            width: '30%',
-            marginLeft: '5%',
-            marginTop: '5%',
             display: 'flex',
             flexWrap: 'wrap',
         },
-        textField: {
-            marginLeft: 8,
-            marginRight: 8,
-            width: 200,
+        formControl: {
+            marginLeft: '5%',
+            marginTop: '5%',
+            minWidth: 120,
         },
         loadingIcon: {
             margin: 'auto',
@@ -112,9 +106,9 @@ export default function APIMTopFaultyApis(props) {
             >
                 <div style={{
                     backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
-                    width: '80%',
-                    margin: '5% auto',
-                    padding: '10% 5%',
+                    height,
+                    margin: '10px',
+                    padding: '20px',
                 }}
                 >
                     <div style={styles.headingWrapper}>
@@ -138,7 +132,7 @@ export default function APIMTopFaultyApis(props) {
                                 value={limit}
                                 onChange={handleChange}
                                 type='number'
-                                style={styles.textField}
+                                style={styles.formControl}
                                 InputLabelProps={{
                                     shrink: true,
                                 }}

--- a/components/org.wso2.analytics.apim.widgets/APIMTopPlatforms/src/APIMTopPlatforms.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopPlatforms/src/APIMTopPlatforms.jsx
@@ -45,41 +45,31 @@ export default function APIMTopPlatforms(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
+            marginBottom:'5%',
         },
         form: {
             display: 'flex',
             flexWrap: 'wrap',
         },
         formControl: {
-            margin: '5%',
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
-        },
-        textField: {
-            margin: '5%',
-            marginTop: 0,
-            minWidth: 120,
-        },
-        selectEmpty: {
-            marginTop: 10,
         },
         dataWrapper: {
             height: '80%',
@@ -97,7 +87,10 @@ export default function APIMTopPlatforms(props) {
             style={{ height }}
         >
             <div style={{
-                padding: '5% 5%',
+                backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                height,
+                margin: '10px',
+                padding: '20px',
             }}
             >
                 <div style={styles.headingWrapper}>
@@ -126,7 +119,6 @@ export default function APIMTopPlatforms(props) {
                                 input={<Input name='apiCreatedBy' id='api-createdBy-label-placeholder' />}
                                 displayEmpty
                                 name='apiCreatedBy'
-                                style={styles.selectEmpty}
                             >
                                 <MenuItem value='All'>
                                     <FormattedMessage id='all.menuItem' defaultMessage='All' />
@@ -146,7 +138,6 @@ export default function APIMTopPlatforms(props) {
                                 input={<Input name='apiSelected' id='apiSelected-label-placeholder' />}
                                 displayEmpty
                                 name='apiSelected'
-                                style={styles.selectEmpty}
                             >
                                 {
                                     apilist.map(option => (
@@ -167,7 +158,6 @@ export default function APIMTopPlatforms(props) {
                                 input={<Input name='apiVersion' id='apiVersion-label-placeholder' />}
                                 displayEmpty
                                 name='apiVersion'
-                                style={styles.selectEmpty}
                             >
                                 {
                                     versionlist.map(option => (
@@ -178,17 +168,13 @@ export default function APIMTopPlatforms(props) {
                                 }
                             </Select>
                         </FormControl>
-                    </form>
-                </div>
-                <div style={styles.formWrapper}>
-                    <form style={styles.form} noValidate autoComplete='off'>
                         <TextField
                             id='limit-number'
                             label={<FormattedMessage id='limit' defaultMessage='Limit :' />}
                             value={limit}
                             onChange={handleLimitChange}
                             type='number'
-                            style={styles.textField}
+                            style={styles.formControl}
                             InputLabelProps={{
                                 shrink: true,
                             }}

--- a/components/org.wso2.analytics.apim.widgets/APIMTopSubscribers/src/APIMTopSubscribers.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopSubscribers/src/APIMTopSubscribers.jsx
@@ -59,25 +59,22 @@ export default function APIMTopSubscribers(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '15%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         form: {
             width: '30%',
@@ -112,9 +109,9 @@ export default function APIMTopSubscribers(props) {
             >
                 <div style={{
                     backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
-                    width: '80%',
-                    margin: '5% auto',
-                    padding: '10% 5%',
+                    height,
+                    margin: '10px',
+                    padding: '20px',
                 }}
                 >
                     <div style={styles.headingWrapper}>

--- a/components/org.wso2.analytics.apim.widgets/APIMTopSubscribers/src/APIMTopSubscribersWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopSubscribers/src/APIMTopSubscribersWidget.jsx
@@ -97,7 +97,7 @@ class APIMTopSubscribersWidget extends Widget {
             legendData: [],
             applications: [],
             subscribers: [],
-            limit: 0,
+            limit: 5,
             localeMessages: null,
             inProgress: true,
         };

--- a/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/APIMTopThrottledApis.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/APIMTopThrottledApis.jsx
@@ -59,37 +59,31 @@ export default function APIMTopThrottledApis(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '15%',
-            margin: 'auto',
+            marginBottom: '5%',
         },
         form: {
-            width: '30%',
-            marginLeft: '5%',
-            marginTop: '5%',
             display: 'flex',
             flexWrap: 'wrap',
         },
-        textField: {
-            marginLeft: 8,
-            marginRight: 8,
-            width: 200,
+        formControl: {
+            marginLeft: '5%',
+            marginTop: '5%',
+            minWidth: 120,
         },
         loadingIcon: {
             margin: 'auto',
@@ -112,9 +106,9 @@ export default function APIMTopThrottledApis(props) {
             >
                 <div style={{
                     backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
-                    width: '80%',
-                    margin: '5% auto',
-                    padding: '10% 5%',
+                    height,
+                    margin: '10px',
+                    padding: '20px',
                 }}
                 >
                     <div style={styles.headingWrapper}>
@@ -138,7 +132,7 @@ export default function APIMTopThrottledApis(props) {
                                 value={limit}
                                 onChange={handleChange}
                                 type='number'
-                                style={styles.textField}
+                                style={styles.formControl}
                                 InputLabelProps={{
                                     shrink: true,
                                 }}

--- a/components/org.wso2.analytics.apim.widgets/APIMTopUserAgents/src/APIMTopAgents.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopUserAgents/src/APIMTopAgents.jsx
@@ -45,41 +45,31 @@ export default function APIMTopAgents(props) {
     } = props;
     const styles = {
         headingWrapper: {
-            height: '10%',
             margin: 'auto',
-            width: '90%',
+            width: '95%',
         },
         paperWrapper: {
             height: '75%',
         },
         paper: {
-            background: '#969696',
+            background: themeName === 'dark' ? '#969696' : '#E8E8E8',
+            borderColor: themeName === 'dark' ? '#fff' : '#D8D8D8',
             width: '75%',
             padding: '4%',
-            border: '1.5px solid #fff',
-            margin: 'auto',
-            marginTop: '5%',
+            border: '1.5px solid',
+            marginLeft:'5%',
         },
         formWrapper: {
-            width: '90%',
-            height: '10%',
-            margin: 'auto',
+            marginBottom:'5%',
         },
         form: {
             display: 'flex',
             flexWrap: 'wrap',
         },
         formControl: {
-            margin: '5%',
+            marginLeft: '5%',
+            marginTop: '5%',
             minWidth: 120,
-        },
-        textField: {
-            margin: '5%',
-            marginTop: 0,
-            minWidth: 120,
-        },
-        selectEmpty: {
-            marginTop: 10,
         },
         dataWrapper: {
             height: '80%',
@@ -101,7 +91,10 @@ export default function APIMTopAgents(props) {
             style={{ height }}
         >
             <div style={{
-                padding: '5% 5%',
+                backgroundColor: themeName === 'dark' ? '#0e1e33' : '#fff',
+                height,
+                margin: '10px',
+                padding: '20px',
             }}
             >
                 <div style={styles.headingWrapper}>
@@ -130,7 +123,6 @@ export default function APIMTopAgents(props) {
                                 input={<Input name='apiCreatedBy' id='api-createdBy-label-placeholder' />}
                                 displayEmpty
                                 name='apiCreatedBy'
-                                style={styles.selectEmpty}
                             >
                                 <MenuItem value='All'>
                                     <FormattedMessage id='all.menuItem' defaultMessage='All' />
@@ -150,7 +142,6 @@ export default function APIMTopAgents(props) {
                                 input={<Input name='apiSelected' id='apiSelected-label-placeholder' />}
                                 displayEmpty
                                 name='apiSelected'
-                                style={styles.selectEmpty}
                             >
                                 {
                                     apilist.map(option => (
@@ -171,7 +162,6 @@ export default function APIMTopAgents(props) {
                                 input={<Input name='apiVersion' id='apiVersion-label-placeholder' />}
                                 displayEmpty
                                 name='apiVersion'
-                                style={styles.selectEmpty}
                             >
                                 {
                                     versionlist.map(option => (
@@ -182,17 +172,13 @@ export default function APIMTopAgents(props) {
                                 }
                             </Select>
                         </FormControl>
-                    </form>
-                </div>
-                <div style={styles.formWrapper}>
-                    <form style={styles.form} noValidate autoComplete='off'>
                         <TextField
                             id='limit-number'
                             label={<FormattedMessage id='limit' defaultMessage='Limit :' />}
                             value={limit}
                             onChange={handleLimitChange}
                             type='number'
-                            style={styles.textField}
+                            style={styles.formControl}
                             InputLabelProps={{
                                 shrink: true,
                             }}


### PR DESCRIPTION
## Purpose
Add blue background to widgets and fix styling issues
Fixes https://github.com/wso2/analytics-apim/issues/866

**dev portal**
_before_
<img width="1651" alt="dev portal page 1 before" src="https://user-images.githubusercontent.com/20040505/70528401-23dc0700-1b74-11ea-82b7-c3e09dc042db.png">
_after_
<img width="1655" alt="dev portal page 1 after" src="https://user-images.githubusercontent.com/20040505/70528402-23dc0700-1b74-11ea-8c63-4cba3f3a476c.png">

**publisher(1)**
_before_
<img width="1665" alt="publisher page 1 before" src="https://user-images.githubusercontent.com/20040505/70528397-23437080-1b74-11ea-996c-b9c39a9fe8f2.png">
_after_
<img width="1643" alt="publisher page 1 after" src="https://user-images.githubusercontent.com/20040505/70528403-24749d80-1b74-11ea-983c-26a670385d01.png">

**publisher(2)**
_before_
<img width="1666" alt="publisher page 2 before" src="https://user-images.githubusercontent.com/20040505/70528400-23dc0700-1b74-11ea-8310-ae7dcb58d3a9.png">
_after_
<img width="1670" alt="publisher page 2 after" src="https://user-images.githubusercontent.com/20040505/70528404-24749d80-1b74-11ea-86d4-dc72f1c4ed6d.png">

**publisher(3)**
_before_
<img width="1662" alt="publisher page 3 before" src="https://user-images.githubusercontent.com/20040505/70528408-250d3400-1b74-11ea-9a14-7a7c47ec162f.png">
_after_
<img width="1671" alt="publisher page 3 after" src="https://user-images.githubusercontent.com/20040505/70528405-24749d80-1b74-11ea-87fb-e2acd62c7562.png">

**publisher(4)**
_before_
<img width="1657" alt="publisher page 4 before" src="https://user-images.githubusercontent.com/20040505/70528409-250d3400-1b74-11ea-94d1-1341a01fabda.png">
_after_
<img width="1680" alt="publisher page 4 after" src="https://user-images.githubusercontent.com/20040505/70528407-250d3400-1b74-11ea-8030-3106585cd592.png">



