### PR TITLE
Fix issues in login flow

### DIFF
--- a/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClient.java
+++ b/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClient.java
@@ -353,7 +353,7 @@ public class ApimIdPClient extends ExternalIdPClient {
             returnProperties.put(IdPClientConstants.CLIENT_ID, this.oAuthAppInfoMap.get(oAuthAppContext).getClientId());
             returnProperties.put(IdPClientConstants.REDIRECTION_URL, this.authorizeEndpoint);
             returnProperties.put(IdPClientConstants.CALLBACK_URL, this.baseUrl +
-                    ApimIdPClientConstants.CALLBACK_URL + callbackUrl);
+                    ApimIdPClientConstants.CALLBACK_URL + callbackUrl + ApimIdPClientConstants.CALLBACK_URL_SUFFIX);
             returnProperties.put(IdPClientConstants.SCOPE, this.allScopes);
             return returnProperties;
         } else if (IdPClientConstants.PASSWORD_GRANT_TYPE.equals(grantType)) {
@@ -472,7 +472,8 @@ public class ApimIdPClient extends ExternalIdPClient {
         }
         OAuthApplicationInfo oAuthApplicationInfo = this.oAuthAppInfoMap.get(oAuthAppContext);
         Response response = oAuth2ServiceStubs.getTokenServiceStub().generateAuthCodeGrantAccessToken(code,
-                this.baseUrl + ApimIdPClientConstants.CALLBACK_URL + oAuthAppContext, null,
+                this.baseUrl + ApimIdPClientConstants.CALLBACK_URL + oAuthAppContext +
+                        ApimIdPClientConstants.CALLBACK_URL_SUFFIX, null,
                 oAuthApplicationInfo.getClientId(), oAuthApplicationInfo.getClientSecret());
         if (response == null) {
             String error = "Error occurred while generating an access token from code '" + code + "'. " +
@@ -643,8 +644,8 @@ public class ApimIdPClient extends ExternalIdPClient {
                     ApimIdPClientConstants.CALLBACK_URL + REGEX_BASE + postLogoutRedirectUrl + REGEX_BASE_END;
         } else {
             callBackUrl = ApimIdPClientConstants.REGEX_BASE_START + this.baseUrl +
-                    ApimIdPClientConstants.CALLBACK_URL + appContext + REGEX_BASE + postLogoutRedirectUrl
-                    + REGEX_BASE_END;
+                    ApimIdPClientConstants.CALLBACK_URL + appContext + ApimIdPClientConstants.CALLBACK_URL_SUFFIX +
+                    REGEX_BASE + postLogoutRedirectUrl + REGEX_BASE_END;
         }
 
         if (LOG.isDebugEnabled()) {

--- a/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClientConstants.java
+++ b/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClientConstants.java
@@ -85,9 +85,10 @@ public class ApimIdPClientConstants {
     public static final String INTROSPECTION_URL = "introspectionUrl";
 
     public static final String CALLBACK_URL = "/login/callback/";
+    public static final String CALLBACK_URL_SUFFIX = "/login";
     public static final String REGEX_BASE_START = "regexp=(";
     public static final String FORWARD_SLASH = "/";
-    public static final String REGEX_BASE = ".*|";
+    public static final String REGEX_BASE = "|";
     public static final String REGEX_BASE_END = ")";
     public static final String SPACE = " ";
     public static final String AT = "@";


### PR DESCRIPTION
## Purpose
This PR fixes redirections in the login flow so that Secured Router is not called twice during the login flow.

Resolves https://github.com/wso2/analytics-apim/issues/812
The above issue is caused because the refresh token call is happening twice as the SetInterval in the secured router is getting registered twice. So the second refresh token call fails and hence the token map is not getting updated with the correct access token. So when we call the dashboard api to get the list of dashboards with the existing token, 403 error is returned from the rest api and hence the front end returns an empty array.

## Goals
SetInterval function in the Secured Router gets registered twice as the Secured Router getting called twice in the login flow.
### Existing login flow
/analytics-dashboard --> Secured Router --> Login --> IDP --> /analytics-dashboard --> Secured Router --> Login ( Set Cookies) --> Call referer ( /analytics-dashboard ) --> Secured Router --> Dashboard listing page

Above flow is modified so that the Secured Router is called only once after the redirection from IDP by changing the callback URL to /analytics-dashboard/login

### Modified login flow
/analytics-dashboard --> Secured Router --> Login --> IDP --> /analytics-dashboard/login --> Login ( Set Cookies) --> Call referer ( /analytics-dashboard ) --> Secured Router --> Dashboard listing page