### PR TITLE
Add api version and creator to publisher faulty stats widgets

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/APIMTopFaultyApisWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/APIMTopFaultyApisWidget.jsx
@@ -222,11 +222,11 @@ class APIMTopFaultyApisWidget extends Widget {
             let apiName = '';
             data.forEach((dataUnit) => {
                 counter += 1;
-                apiName = dataUnit[0] + ' ' + dataUnit[1];
+                apiName = dataUnit[0] + ' (' + dataUnit[2] + ')';
                 if (!legendData.includes({ name: apiName })) {
                     legendData.push({ name: apiName });
                 }
-                faultData.push({ id: counter, apiname: apiName, faultcount: dataUnit[4] });
+                faultData.push({ id: counter, apiname: apiName, apiVersion: dataUnit[1], faultcount: dataUnit[4] });
             });
 
             this.setState({ legendData, faultData, inProgress: false });

--- a/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/CustomTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/CustomTable.jsx
@@ -199,6 +199,9 @@ class CustomTable extends React.Component {
             <MenuItem value='apiname'>
                 <FormattedMessage id='table.heading.apiname' defaultMessage='API NAME' />
             </MenuItem>,
+            <MenuItem value='apiVersion'>
+                <FormattedMessage id='table.heading.apiVersion' defaultMessage='API VERSION' />
+            </MenuItem>,
             <MenuItem value='faultcount'>
                 <FormattedMessage id='table.heading.faultcount' defaultMessage='FAULT COUNT' />
             </MenuItem>,
@@ -234,6 +237,9 @@ class CustomTable extends React.Component {
                                         >
                                             <TableCell component='th' scope='row'>
                                                 {n.apiname}
+                                            </TableCell>
+                                            <TableCell component='th' scope='row' numeric>
+                                                {n.apiVersion}
                                             </TableCell>
                                             <TableCell numeric>
                                                 {n.faultcount}

--- a/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/CustomTableHead.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/CustomTableHead.jsx
@@ -31,6 +31,9 @@ const rows = [
         id: 'apiname', numeric: false, disablePadding: false, label: 'table.heading.apiname',
     },
     {
+        id: 'apiVersion', numeric: true, disablePadding: false, label: 'table.heading.apiVersion',
+    },
+    {
         id: 'faultcount', numeric: true, disablePadding: false, label: 'table.heading.faultcount',
     },
 ];

--- a/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/resources/locales/en.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/resources/locales/en.json
@@ -9,6 +9,7 @@
   "nodata.error.body": "No data available for the selected options.",
   "sort.label.title": "Sort",
   "table.heading.apiname": "API NAME",
+  "table.heading.apiVersion": "API VERSION",
   "table.heading.faultcount": "FAULT COUNT",
   "widget.heading": "TOP FAULTY APIS"
 }

--- a/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/APIMTopThrottledApisWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/APIMTopThrottledApisWidget.jsx
@@ -224,11 +224,12 @@ class APIMTopThrottledApisWidget extends Widget {
             let apiName = '';
             data.forEach((dataUnit) => {
                 counter += 1;
-                apiName = dataUnit[0] + ' ' + dataUnit[1];
+                apiName = dataUnit[0] + ' (' + dataUnit[2] + ')';
                 if (!legendData.includes({ name: apiName })) {
                     legendData.push({ name: apiName });
                 }
-                throttledData.push({ id: counter, apiname: apiName, throttledcount: dataUnit[4] });
+                throttledData.push({ id: counter, apiname: apiName, apiVersion: dataUnit[1],
+                    throttledcount: dataUnit[4] });
             });
 
             this.setState({ legendData, throttledData, inProgress: false });

--- a/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/CustomTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/CustomTable.jsx
@@ -207,6 +207,9 @@ class CustomTable extends React.Component {
             <MenuItem value='apiname'>
                 <FormattedMessage id='table.heading.apiname' defaultMessage='API NAME' />
             </MenuItem>,
+            <MenuItem value='apiname'>
+                <FormattedMessage id='table.heading.apiVersion' defaultMessage='API VERSION' />
+            </MenuItem>,
             <MenuItem value='throttledcount'>
                 <FormattedMessage id='table.heading.throttledcount' defaultMessage='THROTTLED OUT COUNT' />
             </MenuItem>,
@@ -243,12 +246,10 @@ class CustomTable extends React.Component {
                                             <TableCell component='th' scope='row'>
                                                 {n.apiname}
                                             </TableCell>
-                                            <TableCell
-                                                numeric
-                                                style={{
-                                                    paddingRight: '10%',
-                                                }}
-                                            >
+                                            <TableCell component='th' scope='row' numeric>
+                                                {n.apiVersion}
+                                            </TableCell>
+                                            <TableCell component='th' scope='row' numeric>
                                                 {n.throttledcount}
                                             </TableCell>
                                         </TableRow>

--- a/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/CustomTableHead.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/CustomTableHead.jsx
@@ -31,6 +31,9 @@ const rows = [
         id: 'apiname', numeric: false, disablePadding: false, label: 'table.heading.apiname',
     },
     {
+        id: 'apiVersion', numeric: true, disablePadding: false, label: 'table.heading.apiVersion',
+    },
+    {
         id: 'throttledcount', numeric: true, disablePadding: false, label: 'table.heading.throttledcount',
     },
 ];

--- a/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/resources/locales/en.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/resources/locales/en.json
@@ -9,6 +9,7 @@
   "nodata.error.body": "No data available for the selected options.",
   "sort.label.title": "Sort",
   "table.heading.apiname": "API NAME",
+  "table.heading.apiVersion": "API VERSION",
   "table.heading.throttledcount": "THROTTLED OUT COUNT",
   "widget.heading": "TOP THROTTLED OUT APIS"
 }


### PR DESCRIPTION
## Purpose
Add api version and creator to publisher faulty stats widgets
Fixes https://github.com/wso2/analytics-apim/issues/876

<img width="1564" alt="Screen Shot 2019-12-16 at 12 03 01 PM" src="https://user-images.githubusercontent.com/20040505/70884622-857cf500-1ffc-11ea-8a2f-ea2824121915.png">

