### PR TITLE
Remove display of circular progress when date picker is on sync

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/APIMApiBackendUsageSummary/src/APIMApiBackendUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiBackendUsageSummary/src/APIMApiBackendUsageWidget.jsx
@@ -194,11 +194,14 @@ class APIMApiBackendUsageWidget extends Widget {
      * @memberof APIMApiBackendUsageWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleApiUsageQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMApiCreatedAnalytics/src/APIMApiCreatedAnalyticsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiCreatedAnalytics/src/APIMApiCreatedAnalyticsWidget.jsx
@@ -199,10 +199,13 @@ class APIMApiCreatedAnalyticsWidget extends Widget {
      * @memberof APIMApiCreatedAnalyticsWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMApiLatencyTime/src/APIMApiLatencyWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiLatencyTime/src/APIMApiLatencyWidget.jsx
@@ -299,11 +299,14 @@ class APIMApiLatencyWidget extends Widget {
      * @memberof APIMApiLatencyWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleApiListQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMApiResourceUsageSummary/src/APIMApiResourceUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiResourceUsageSummary/src/APIMApiResourceUsageWidget.jsx
@@ -194,11 +194,14 @@ class APIMApiResourceUsageWidget extends Widget {
      * @memberof APIMApiResourceUsageWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleApiUsageQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMApiResponseSummary/src/APIMApiResponseWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiResponseSummary/src/APIMApiResponseWidget.jsx
@@ -175,11 +175,14 @@ class APIMApiResponseWidget extends Widget {
      * @memberof APIMApiResponseWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleApiListQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMApiUsage/src/APIMApiUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiUsage/src/APIMApiUsageWidget.jsx
@@ -201,11 +201,14 @@ class APIMApiUsageWidget extends Widget {
      * @memberof APIMApiUsageWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleApiListQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMApiVersionUsageSummary/src/APIMApiVersionUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiVersionUsageSummary/src/APIMApiVersionUsageWidget.jsx
@@ -193,11 +193,14 @@ class APIMApiVersionUsageWidget extends Widget {
      * @memberof APIMApiVersionUsageWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleApiUsageQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMAppApiUsage/src/APIMAppApiUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAppApiUsage/src/APIMAppApiUsageWidget.jsx
@@ -206,11 +206,14 @@ class APIMAppApiUsageWidget extends Widget {
      * @memberof APIMAppApiUsageWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleAppQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMAppCreatedAnalytics/src/APIMAppCreatedAnalyticsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAppCreatedAnalytics/src/APIMAppCreatedAnalyticsWidget.jsx
@@ -212,10 +212,13 @@ class APIMAppCreatedAnalyticsWidget extends Widget {
      * @memberof APIMAppCreatedAnalyticsWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleSubListQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMAppResourceUsage/src/APIMAppResourceUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAppResourceUsage/src/APIMAppResourceUsageWidget.jsx
@@ -307,11 +307,14 @@ class APIMAppResourceUsageWidget extends Widget {
      * @memberof APIMAppResourceUsageWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleAppQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMFaultyPerApp/src/APIMFaultyPerAppWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMFaultyPerApp/src/APIMFaultyPerAppWidget.jsx
@@ -206,11 +206,14 @@ class APIMFaultyPerAppWidget extends Widget {
      * @memberof APIMFaultyPerAppWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleAppQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMGeoBasedInvocations/src/APIMGeoInvocationsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMGeoBasedInvocations/src/APIMGeoInvocationsWidget.jsx
@@ -237,11 +237,14 @@ class APIMGeoInvocationsWidget extends Widget {
      * @memberof APIMGeoInvocationsWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleApiListQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMOverallApiUsage/src/APIMOverallApiUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMOverallApiUsage/src/APIMOverallApiUsageWidget.jsx
@@ -235,11 +235,14 @@ class APIMOverallApiUsageWidget extends Widget {
      * @memberof APIMOverallApiUsageWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleApiUsageQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMSignupsAnalytics/src/APIMSignupsAnalyticsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMSignupsAnalytics/src/APIMSignupsAnalyticsWidget.jsx
@@ -166,10 +166,13 @@ class APIMSignupsAnalyticsWidget extends Widget {
      * @memberof APIMSignupsAnalyticsWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMSubscriptionsAnalytics/src/APIMSubscriptionsAnalyticsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMSubscriptionsAnalytics/src/APIMSubscriptionsAnalyticsWidget.jsx
@@ -196,10 +196,13 @@ class APIMSubscriptionsAnalyticsWidget extends Widget {
      * @memberof APIMSubscriptionsAnalyticsWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleApiListQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMTopApiUsers/src/APIMTopApiUsersWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopApiUsers/src/APIMTopApiUsersWidget.jsx
@@ -201,11 +201,14 @@ class APIMTopApiUsersWidget extends Widget {
      * @memberof APIMTopApiUsersWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleApiListQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMTopAppUsers/src/APIMTopAppUsersWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopAppUsers/src/APIMTopAppUsersWidget.jsx
@@ -206,11 +206,14 @@ class APIMTopAppUsersWidget extends Widget {
      * @memberof APIMTopAppUsersWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleAppQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/APIMTopFaultyApisWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/APIMTopFaultyApisWidget.jsx
@@ -168,11 +168,14 @@ class APIMTopFaultyApisWidget extends Widget {
      * @memberof APIMTopFaultyApisWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMTopPlatforms/src/APIMTopPlatformsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopPlatforms/src/APIMTopPlatformsWidget.jsx
@@ -206,11 +206,14 @@ class APIMTopPlatformsWidget extends Widget {
      * @memberof APIMTopPlatformsWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleApiListQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/APIMTopThrottledApisWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/APIMTopThrottledApisWidget.jsx
@@ -169,11 +169,14 @@ class APIMTopThrottledApisWidget extends Widget {
      * @memberof APIMTopThrottledApisWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleQuery);
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMTopUserAgents/src/APIMTopAgentsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopUserAgents/src/APIMTopAgentsWidget.jsx
@@ -215,11 +215,14 @@ class APIMTopAgentsWidget extends Widget {
      * @memberof APIMTopAgentsWidget
      * */
     handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+
         this.setState({
             timeFrom: receivedMsg.from,
             timeTo: receivedMsg.to,
             perValue: receivedMsg.granularity,
-            inProgress: true,
+            inProgress: !sync,
         }, this.assembleApiListQuery);
     }
 


### PR DESCRIPTION
## Purpose
Remove the display of circular progress when refreshing is enabled for the date picker.