### PR TITLE
Fixes the static count issue in the geolocation based invocation widget.

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/APIMGeoBasedInvocations/src/APIMGeoInvocationsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMGeoBasedInvocations/src/APIMGeoInvocationsWidget.jsx
@@ -166,7 +166,6 @@ class APIMGeoInvocationsWidget extends Widget {
         this.apiVersionHandleChange = this.apiVersionHandleChange.bind(this);
         this.resetState = this.resetState.bind(this);
         this.getUsername = this.getUsername.bind(this);
-        this.setchloropethRangeUpperbound = this.setchloropethRangeUpperbound.bind(this);
     }
 
     componentWillMount() {
@@ -385,28 +384,12 @@ class APIMGeoInvocationsWidget extends Widget {
 
         if (data) {
             const { apiCreatedBy, apiSelected, apiVersion } = this.state;
-            this.setchloropethRangeUpperbound(data);
+            const maxCount = data.reduce((acc,cur) => cur[0] > acc ? acc = cur[0] : acc, 0);
+            this.chartConfig.chloropethRangeUpperbound = [maxCount];
             this.setState({ geoData: data, inProgress: false });
             this.setQueryParam(apiCreatedBy, apiSelected, apiVersion);
         } else {
             this.setState({ inProgress: false, geoData: [] });
-        }
-    }
-
-    /**
-     * Sets the upper bound for geochart range
-     * @param {object} data - data for the geochart
-     * @memberof APIMGeoInvocationsWidget
-     */
-    setchloropethRangeUpperbound(data) {
-        let maxCount = 1;
-        if (data.length > 0) {
-            data.map((dataPoint) => {
-                if (dataPoint[0] > maxCount) {
-                    maxCount = dataPoint[0];
-                }
-            });
-            this.chartConfig.chloropethRangeUpperbound = [maxCount];
         }
     }
 

--- a/components/org.wso2.analytics.apim.widgets/APIMGeoBasedInvocations/src/APIMGeoInvocationsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMGeoBasedInvocations/src/APIMGeoInvocationsWidget.jsx
@@ -166,6 +166,7 @@ class APIMGeoInvocationsWidget extends Widget {
         this.apiVersionHandleChange = this.apiVersionHandleChange.bind(this);
         this.resetState = this.resetState.bind(this);
         this.getUsername = this.getUsername.bind(this);
+        this.setchloropethRangeUpperbound = this.setchloropethRangeUpperbound.bind(this);
     }
 
     componentWillMount() {
@@ -384,10 +385,28 @@ class APIMGeoInvocationsWidget extends Widget {
 
         if (data) {
             const { apiCreatedBy, apiSelected, apiVersion } = this.state;
+            this.setchloropethRangeUpperbound(data);
             this.setState({ geoData: data, inProgress: false });
             this.setQueryParam(apiCreatedBy, apiSelected, apiVersion);
         } else {
             this.setState({ inProgress: false, geoData: [] });
+        }
+    }
+
+    /**
+     * Sets the upper bound for geochart range
+     * @param {object} data - data for the geochart
+     * @memberof APIMGeoInvocationsWidget
+     */
+    setchloropethRangeUpperbound(data) {
+        let maxCount = 1;
+        if (data.length > 0) {
+            data.map((dataPoint) => {
+                if (dataPoint[0] > maxCount) {
+                    maxCount = dataPoint[0];
+                }
+            });
+            this.chartConfig.chloropethRangeUpperbound = [maxCount];
         }
     }
 


### PR DESCRIPTION
## Purpose
Fixes the static count issue in the Geo-location based invocation widget.

## Approach
Instead of putting a static value to the range, the maximum hit count among countries set as the upper bound.

## Automation tests
 - Integration tests
   Locally tested the widget replacing in the analytics distribution.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
npm 6.14.2, node v8.10.0, Firefox (74.0)