### PR TITLE
Fixes resetting the limit drop-down value when refreshing the page, removes 0 from drop-down option..

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/APIMApiBackendUsageSummary/src/APIMApiBackendUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiBackendUsageSummary/src/APIMApiBackendUsageWidget.jsx
@@ -102,7 +102,7 @@ class APIMApiBackendUsageWidget extends Widget {
             width: this.props.width,
             height: this.props.height,
             apiCreatedBy: 'All',
-            limit: 0,
+            limit: 5,
             usageData: null,
             localeMessages: null,
             inProgress: true,

--- a/components/org.wso2.analytics.apim.widgets/APIMApiLastAccessSummary/src/APIMApiLastAccessWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiLastAccessSummary/src/APIMApiLastAccessWidget.jsx
@@ -93,7 +93,7 @@ class APIMApiLastAccessWidget extends Widget {
             width: this.props.width,
             height: this.props.height,
             apiCreatedBy: 'All',
-            limit: 0,
+            limit: 5,
             accessData: null,
             localeMessages: null,
             inProgress: true,

--- a/components/org.wso2.analytics.apim.widgets/APIMApiResourceUsageSummary/src/APIMApiResourceUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiResourceUsageSummary/src/APIMApiResourceUsageWidget.jsx
@@ -102,7 +102,7 @@ class APIMApiResourceUsageWidget extends Widget {
             width: this.props.width,
             height: this.props.height,
             apiCreatedBy: 'All',
-            limit: 0,
+            limit: 5,
             usageData: null,
             localeMessages: null,
             inProgress: true,

--- a/components/org.wso2.analytics.apim.widgets/APIMApiUsage/src/APIMApiUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiUsage/src/APIMApiUsageWidget.jsx
@@ -112,7 +112,7 @@ class APIMApiUsageWidget extends Widget {
         this.state = {
             width: this.props.width,
             height: this.props.height,
-            limit: 0,
+            limit: 5,
             apiCreatedBy: 'All',
             apiSelected: 'All',
             apiVersion: 'All',

--- a/components/org.wso2.analytics.apim.widgets/APIMApiVersionUsageSummary/src/APIMApiVersionUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiVersionUsageSummary/src/APIMApiVersionUsageWidget.jsx
@@ -102,7 +102,7 @@ class APIMApiVersionUsageWidget extends Widget {
             width: this.props.width,
             height: this.props.height,
             apiCreatedBy: 'All',
-            limit: 0,
+            limit: 5,
             usageData: null,
             localeMessages: null,
             inProgress: true,

--- a/components/org.wso2.analytics.apim.widgets/APIMAppApiUsage/src/APIMAppApiUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAppApiUsage/src/APIMAppApiUsageWidget.jsx
@@ -326,7 +326,13 @@ class APIMAppApiUsageWidget extends Widget {
             timeFrom, timeTo, perValue, providerConfig, applicationList,
         } = this.state;
         const queryParam = super.getGlobalState(queryParamKey);
-        const { applicationSelected, limit } = queryParam;
+        let { applicationSelected, limit } = queryParam;
+
+        if (!limit || limit < 0) {
+            limit = 5;
+        }
+
+        this.setState({ limit });
 
         if (applicationSelected && limit && providerConfig) {
             const { id, widgetID: widgetName } = this.props;

--- a/components/org.wso2.analytics.apim.widgets/APIMAppResourceUsage/src/APIMAppResourceUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAppResourceUsage/src/APIMAppResourceUsageWidget.jsx
@@ -327,7 +327,13 @@ class APIMAppResourceUsageWidget extends Widget {
             timeFrom, timeTo, perValue, providerConfig, applicationList,
         } = this.state;
         const queryParam = super.getGlobalState(queryParamKey);
-        const { applicationSelected, limit } = queryParam;
+        let { applicationSelected, limit } = queryParam;
+
+        if (!limit || limit < 0) {
+            limit = 5;
+        }
+
+        this.setState({ limit });
 
         if (applicationSelected && limit) {
             const { id, widgetID: widgetName } = this.props;

--- a/components/org.wso2.analytics.apim.widgets/APIMFaultyPerApp/src/APIMFaultyPerAppWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMFaultyPerApp/src/APIMFaultyPerAppWidget.jsx
@@ -326,7 +326,13 @@ class APIMFaultyPerAppWidget extends Widget {
             timeFrom, timeTo, perValue, providerConfig, applicationList,
         } = this.state;
         const queryParam = super.getGlobalState(queryParamKey);
-        const { applicationSelected, limit } = queryParam;
+        let { applicationSelected, limit } = queryParam;
+
+        if (!limit || limit < 0) {
+            limit = 5;
+        }
+
+        this.setState({ limit });
 
         if (applicationSelected && limit) {
             const { id, widgetID: widgetName } = this.props;

--- a/components/org.wso2.analytics.apim.widgets/APIMOverallApiUsage/src/APIMOverallApiUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMOverallApiUsage/src/APIMOverallApiUsageWidget.jsx
@@ -136,7 +136,7 @@ class APIMOverallApiUsageWidget extends Widget {
             apiDataList: [],
             metadata: this.metadata,
             chartConfig: this.chartConfig,
-            limit: 0,
+            limit: 5,
             localeMessages: null,
             inProgress: true,
             proxyError: false,

--- a/components/org.wso2.analytics.apim.widgets/APIMTopApiCreators/src/APIMTopApiCreatorsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopApiCreators/src/APIMTopApiCreatorsWidget.jsx
@@ -107,7 +107,7 @@ class APIMTopApiCreatorsWidget extends Widget {
             apiDataList: [],
             creatorData: [],
             legendData: [],
-            limit: 0,
+            limit: 5,
             localeMessages: null,
             inProgress: true,
             proxyError: false,

--- a/components/org.wso2.analytics.apim.widgets/APIMTopApiUsers/src/APIMTopApiUsersWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopApiUsers/src/APIMTopApiUsersWidget.jsx
@@ -112,7 +112,7 @@ class APIMTopApiUsersWidget extends Widget {
         this.state = {
             width: this.props.width,
             height: this.props.height,
-            limit: 0,
+            limit: 5,
             apiCreatedBy: 'All',
             apiSelected: 'All',
             apiVersion: 'All',

--- a/components/org.wso2.analytics.apim.widgets/APIMTopAppCreators/src/APIMTopAppCreatorsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopAppCreators/src/APIMTopAppCreatorsWidget.jsx
@@ -210,6 +210,9 @@ class APIMTopAppCreatorsWidget extends Widget {
         if (!limit || limit < 0) {
             limit = 5;
         }
+
+        this.setState({ limit });
+
         if (subscribers && subscribers.length > 0) {
             const dataProviderConfigs = cloneDeep(providerConfig);
             let subs = subscribers.map((sub) => { return 'SUBSCRIBER_ID==' + sub; });

--- a/components/org.wso2.analytics.apim.widgets/APIMTopAppUsers/src/APIMTopAppUsersWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopAppUsers/src/APIMTopAppUsersWidget.jsx
@@ -324,7 +324,13 @@ class APIMTopAppUsersWidget extends Widget {
             timeFrom, timeTo, perValue, providerConfig, applicationList,
         } = this.state;
         const queryParam = super.getGlobalState(queryParamKey);
-        const { applicationSelected, limit } = queryParam;
+        let { applicationSelected, limit } = queryParam;
+
+        if (!limit || limit < 0) {
+            limit = 5;
+        }
+
+        this.setState({ limit });
 
         if (applicationSelected && limit) {
             const { id, widgetID: widgetName } = this.props;

--- a/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/APIMTopFaultyApisWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/APIMTopFaultyApisWidget.jsx
@@ -95,7 +95,7 @@ class APIMTopFaultyApisWidget extends Widget {
             height: this.props.height,
             faultData: null,
             legendData: null,
-            limit: 0,
+            limit: 5,
             localeMessages: null,
             inProgress: true,
         };

--- a/components/org.wso2.analytics.apim.widgets/APIMTopPlatforms/src/APIMTopPlatformsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopPlatforms/src/APIMTopPlatformsWidget.jsx
@@ -116,7 +116,7 @@ class APIMTopPlatformsWidget extends Widget {
         this.state = {
             width: this.props.width,
             height: this.props.height,
-            limit: 0,
+            limit: 5,
             apiCreatedBy: 'All',
             apiSelected: 'All',
             apiVersion: 'All',

--- a/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/APIMTopThrottledApisWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/APIMTopThrottledApisWidget.jsx
@@ -95,7 +95,7 @@ class APIMTopThrottledApisWidget extends Widget {
             height: this.props.height,
             throttledData: null,
             legendData: null,
-            limit: 0,
+            limit: 5,
             localeMessages: null,
             inProgress: true,
         };

--- a/components/org.wso2.analytics.apim.widgets/APIMTopUserAgents/src/APIMTopAgentsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopUserAgents/src/APIMTopAgentsWidget.jsx
@@ -112,7 +112,7 @@ class APIMTopAgentsWidget extends Widget {
         this.state = {
             width: this.props.width,
             height: this.props.height,
-            limit: 0,
+            limit: 5,
             apiCreatedBy: 'All',
             apiSelected: 'All',
             apiVersion: 'All',


### PR DESCRIPTION
## Purpose
Fixes issues https://github.com/wso2/analytics-apim/issues/1090, https://github.com/wso2/analytics-apim/issues/1092, https://github.com/wso2/analytics-apim/issues/1093

## Goals
Fixing some issues related to the limit drop-down in analytics widgets.

## Approach
When refreshing the page, the previous limit value is kept.
The 0 option is removed from the limit drop-down.

## Automation tests
 - Integration tests
   Tested the modified widgets in the local setup.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
npm 6.14.2, node v8.10.0, Firefox (74.0)