### PR TITLE
Fix "Config used to obfuscate PII content of a user from log file is incorrect" issue.

### DIFF
--- a/product/distribution/carbon-home/bin/icf-provider.sh
+++ b/product/distribution/carbon-home/bin/icf-provider.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # ---------------------------------------------------------------------------
-#  Copyright (c) 2019, WSO7 Inc. (http://www.wso2.org) All Rights Reserved.
+#  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/product/distribution/src/assembly/bin.xml
+++ b/product/distribution/src/assembly/bin.xml
@@ -328,9 +328,8 @@
         </file>
 
         <file>
-            <source>target/forget-me/identity-anonymization-tool-${forgetme.tool.version}/conf/product-config/config-sp.json</source>
+            <source>src/forgetme-tool/config.json</source>
             <outputDirectory>wso2/tools/identity-anonymization-tool/conf/</outputDirectory>
-            <destName>config.json</destName>
             <fileMode>644</fileMode>
         </file>
 

--- a/product/distribution/src/forgetme-tool/config.json
+++ b/product/distribution/src/forgetme-tool/config.json
@@ -1,0 +1,21 @@
+{
+  "processors" : [
+    "log-file"
+  ],
+  "directories": [
+    {
+      "dir": "log-config1",
+      "type": "log-file",
+      "processor" : "log-file",
+      "log-file-path" : "<API-M_ANALYTICS_HOME>/wso2/worker/logs",
+      "log-file-name-regex" : "(.)*(log|out)"
+    },
+    {
+      "dir": "log-config2",
+      "type": "log-file",
+      "processor" : "log-file",
+      "log-file-path" : "<API-M_ANALYTICS_HOME>/wso2/dashboard/logs",
+      "log-file-name-regex" : "(.)*(log|out)"
+    }
+  ]
+}

--- a/product/distribution/src/forgetme-tool/config.json
+++ b/product/distribution/src/forgetme-tool/config.json
@@ -4,14 +4,14 @@
   ],
   "directories": [
     {
-      "dir": "log-config1",
+      "dir": "worker-logs",
       "type": "log-file",
       "processor" : "log-file",
       "log-file-path" : "<API-M_ANALYTICS_HOME>/wso2/worker/logs",
       "log-file-name-regex" : "(.)*(log|out)"
     },
     {
-      "dir": "log-config2",
+      "dir": "dashboard-logs",
       "type": "log-file",
       "processor" : "log-file",
       "log-file-path" : "<API-M_ANALYTICS_HOME>/wso2/dashboard/logs",


### PR DESCRIPTION
## Purpose
This PR fixes https://github.com/wso2/analytics-apim/issues/1111 by replacing the incorrect `config.json` file with the correct configurations included `config.json` file.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes