### PR TITLE
Add apiNameColumn to ApimAllAlert table

### DIFF
--- a/features/org.wso2.analytics.apim.feature/src/main/resources/siddhi-files/APIM_PERSIST_ALERTS.siddhi
+++ b/features/org.wso2.analytics.apim.feature/src/main/resources/siddhi-files/APIM_PERSIST_ALERTS.siddhi
@@ -46,7 +46,7 @@ define stream TierLimitHittingAlertStream(subscriber string, apiCreator string, 
 define stream IpAccessAbnormalityAlertStream(type string, message string, severity int, ip string, applicationName string, applicationOwner string, username string, tenantDomain string, requestTimestamp long, alertTimestamp long);
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB', field.length = "message:3000")
-define table ApimAllAlert (type string, tenantDomain string, message string, severity int, alertTimestamp long);
+define table ApimAllAlert (type string, tenantDomain string, message string, severity int, alertTimestamp long, apiName string);
 
 @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB', field.length = "message:3000")
 define table ApimAbnormalBackendTimeAlert (apiName string, apiVersion string, apiCreator string, apiCreatorTenantDomain string, apiResourceTemplate string, apiMethod string, backendTime long, thresholdBackendTime long,
@@ -72,37 +72,37 @@ define table ApimTierLimitHittingAlert (subscriber string, apiCreator string, ap
 
 @info(name = 'AbnormalBackendTimeAlert insert to ApimAllAlert')
 from AbnormalBackendTimeAlertStream
-select 'AbnormalBackendTime' as type, apiCreatorTenantDomain as tenantDomain, str:concat('Abnormal backend time detected for http ', apiMethod, ' method of resource template:', apiResourceTemplate, ' in api:', apiName, ' of tenant domain:', apiCreatorTenantDomain, ', threshold value:', convert(thresholdBackendTime, 'string'), 'ms.') as message, severity, alertTimestamp
+select 'AbnormalBackendTime' as type, apiCreatorTenantDomain as tenantDomain, str:concat('Abnormal backend time detected for http ', apiMethod, ' method of resource template:', apiResourceTemplate, ' in api:', apiName, ' of tenant domain:', apiCreatorTenantDomain, ', threshold value:', convert(thresholdBackendTime, 'string'), 'ms.') as message, severity, alertTimestamp, apiName
 insert into ApimAllAlert;
 
 @info(name = 'AbnormalRequestsCountAlert insert to ApimAllAlert')
 from AbnormalRequestsCountAlertStream
-select 'AbnormalRequestsPerMin' as type, tenantDomain, str:concat('Abnormal request count detected during last minute using application ', applicationName, ' owned by ', applicationOwner, ' for api :', apiName, ', abnormal requst count:', convert(requestCountPerMin, 'string'), ".") as message, severity, alertTimestamp
+select 'AbnormalRequestsPerMin' as type, tenantDomain, str:concat('Abnormal request count detected during last minute using application ', applicationName, ' owned by ', applicationOwner, ' for api :', apiName, ', abnormal requst count:', convert(requestCountPerMin, 'string'), ".") as message, severity, alertTimestamp, apiName
 insert into ApimAllAlert;
 
 @info(name = 'RequestPatternChangedAlertStream insert to ApimAllAlert')
 from RequestPatternChangedAlertStream
-select 'AbnormalRequestPattern' as type, tenantDomain, str:concat('Abnormal request pattern detected by user :', username, ' using application : ', applicationName, ' owned by: ', applicationOwner, ' suspicious API transition is: ', transition, '.') as message, severity, alertTimestamp
+select 'AbnormalRequestPattern' as type, tenantDomain, str:concat('Abnormal request pattern detected by user :', username, ' using application : ', applicationName, ' owned by: ', applicationOwner, ' suspicious API transition is: ', transition, '.') as message, severity, alertTimestamp, 'N/A' as apiName
 insert into ApimAllAlert;
 
 @info(name = 'AbnormalResponseTimeAlertStream insert to ApimAllAlert')
 from AbnormalResponseTimeAlertStream
-select 'AbnormalResponseTime' as type, apiCreatorTenantDomain as tenantDomain, str:concat('Abnormal response time detected for http ', apiMethod, ' method of resource template:', apiResourceTemplate, ' in api:', apiName, ' of tenant domain:', apiCreatorTenantDomain, ', threshold value:', convert(thresholdResponseTime, 'string'), 'ms.') as message, severity, alertTimestamp
+select 'AbnormalResponseTime' as type, apiCreatorTenantDomain as tenantDomain, str:concat('Abnormal response time detected for http ', apiMethod, ' method of resource template:', apiResourceTemplate, ' in api:', apiName, ' of tenant domain:', apiCreatorTenantDomain, ', threshold value:', convert(thresholdResponseTime, 'string'), 'ms.') as message, severity, alertTimestamp, apiName
 insert into ApimAllAlert;
 
 @info(name = 'TierLimitHittingAlertStream insert to ApimAllAlert')
 from TierLimitHittingAlertStream
-select "FrequentTierLimitHitting" as type, userTenantDomain as tenantDomain, message, severity, alertTimestamp
+select "FrequentTierLimitHitting" as type, userTenantDomain as tenantDomain, message, severity, alertTimestamp, apiName
 insert into ApimAllAlert;
 
 @info(name = 'ApiHealthMonitorAlertStream insert to ApimAllAlert')
 from ApiHealthMonitorAlertStream
-select 'ApiHealthMonitor' as type, apiCreatorTenantDomain as tenantDomain, str:concat('API:', apiName, ' ', apiVersion, '-', message) as message, severity, alertTimestamp
+select 'ApiHealthMonitor' as type, apiCreatorTenantDomain as tenantDomain, str:concat('API:', apiName, ' ', apiVersion, '-', message) as message, severity, alertTimestamp, apiName
 insert into ApimAllAlert;
 
 @info(name = 'IpAccessAbnormalityAlertStream insert to ApimAllAlert')
 from IpAccessAbnormalityAlertStream
-select type, tenantDomain, str:concat("A request from a ", ifThenElse(str:contains(message, 'old'), 'old', 'new'), " IP (", ip, ") detected by user:" , username, " using application:", applicationName, " owned by ", applicationOwner, ".") as message, severity, alertTimestamp
+select type, tenantDomain, str:concat("A request from a ", ifThenElse(str:contains(message, 'old'), 'old', 'new'), " IP (", ip, ") detected by user:" , username, " using application:", applicationName, " owned by ", applicationOwner, ".") as message, severity, alertTimestamp, 'N/A' as apiName
 insert into ApimAllAlert;
 
 @info(name = 'Insert to IpAccessAbnormalityAlert')


### PR DESCRIPTION
## Purpose
This PR adds `apiName` column to `ApimAllAlert` table.

Since **Abnormal resource access pattern** alerts and **Unseen source IP address alerts** are generated based on application, for those two alert types, `N/A` will be inserted into the `apiName` column.

For all the other alert types which are:

- Abnormal response time
- Abnormal backend time
- Abnormal request counts
- Frequent tier limit hitting
- Availability of APIs

respective api name is inserted into the `apiName` column.

## Migrations (if applicable)
This schema change will not impact migrations as we don't usually migrate alerts data as they have no historical value. 

## Samples
<img width="1469" alt="add-api-name" src="https://user-images.githubusercontent.com/19996612/80711407-ede0f480-8b0d-11ea-8d33-210478c8fb16.png">

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes