### PR TITLE
Add options config to remove 'All' option in dimension selector for managers

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/DimensionSelector/src/resources/widgetConf.json
+++ b/components/org.wso2.analytics.apim.widgets/DimensionSelector/src/resources/widgetConf.json
@@ -45,6 +45,18 @@
         "defaultValue": true
       },
       {
+        "id" : "selectAll",
+        "title" : "Select 'All' Option",
+        "type" : {
+          "name" : "BOOLEAN",
+          "possibleValues" : [
+            true,
+            false
+          ]
+        },
+        "defaultValue": true
+      },
+      {
         "id" : "dimensions",
         "title" : "Dimension(s)",
         "type" : {


### PR DESCRIPTION
## Purpose
Add options config to remove 'All' option in dimension selector for managers. This support is needed for default loading of dashboard pages with widgets such as latency time and geo location which are unable to render data for 'All' selection. If the 'All' selection is not removed from the options list, then when the user opens the page, the dimension selector will select 'All' option by default and the widgets will not be able to render data.