### PR TITLE
Add API alerts page to monitoring dashboard

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/package-lock.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/package-lock.json
@@ -4,10 +4,316 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/runtime": {
+			"version": "7.10.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+			"integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"@emotion/hash": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+			"integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+		},
+		"@material-ui/core": {
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.10.1.tgz",
+			"integrity": "sha512-bJb/07JFTht0oSjoWMu0j7r1mx4EbJ2ZHx+OKiY+i6IYW/4JPZ1J6rZuFS2b9jT+slSONPZaZq/kHitbE5lcig==",
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@material-ui/styles": "^4.10.0",
+				"@material-ui/system": "^4.9.14",
+				"@material-ui/types": "^5.1.0",
+				"@material-ui/utils": "^4.9.12",
+				"@types/react-transition-group": "^4.2.0",
+				"clsx": "^1.0.4",
+				"hoist-non-react-statics": "^3.3.2",
+				"popper.js": "1.16.1-lts",
+				"prop-types": "^15.7.2",
+				"react-is": "^16.8.0",
+				"react-transition-group": "^4.4.0"
+			}
+		},
+		"@material-ui/icons": {
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.9.1.tgz",
+			"integrity": "sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==",
+			"requires": {
+				"@babel/runtime": "^7.4.4"
+			}
+		},
+		"@material-ui/lab": {
+			"version": "4.0.0-alpha.55",
+			"resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.55.tgz",
+			"integrity": "sha512-mPHiS52Z1AT6NlWNp07xxTkoKGU3DZhoGdVtLKGy2+uMH5t4/UPtiZLRab7hR3hvuHvguxgV4tkBC9ww3xqUzA==",
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@material-ui/utils": "^4.9.6",
+				"clsx": "^1.0.4",
+				"prop-types": "^15.7.2",
+				"react-is": "^16.8.0"
+			}
+		},
+		"@material-ui/styles": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",
+			"integrity": "sha512-XPwiVTpd3rlnbfrgtEJ1eJJdFCXZkHxy8TrdieaTvwxNYj42VnnCyFzxYeNW9Lhj4V1oD8YtQ6S5Gie7bZDf7Q==",
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@emotion/hash": "^0.8.0",
+				"@material-ui/types": "^5.1.0",
+				"@material-ui/utils": "^4.9.6",
+				"clsx": "^1.0.4",
+				"csstype": "^2.5.2",
+				"hoist-non-react-statics": "^3.3.2",
+				"jss": "^10.0.3",
+				"jss-plugin-camel-case": "^10.0.3",
+				"jss-plugin-default-unit": "^10.0.3",
+				"jss-plugin-global": "^10.0.3",
+				"jss-plugin-nested": "^10.0.3",
+				"jss-plugin-props-sort": "^10.0.3",
+				"jss-plugin-rule-value-function": "^10.0.3",
+				"jss-plugin-vendor-prefixer": "^10.0.3",
+				"prop-types": "^15.7.2"
+			}
+		},
+		"@material-ui/system": {
+			"version": "4.9.14",
+			"resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.9.14.tgz",
+			"integrity": "sha512-oQbaqfSnNlEkXEziDcJDDIy8pbvwUmZXWNqlmIwDqr/ZdCK8FuV3f4nxikUh7hvClKV2gnQ9djh5CZFTHkZj3w==",
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@material-ui/utils": "^4.9.6",
+				"csstype": "^2.5.2",
+				"prop-types": "^15.7.2"
+			}
+		},
+		"@material-ui/types": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+			"integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+		},
+		"@material-ui/utils": {
+			"version": "4.9.12",
+			"resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.9.12.tgz",
+			"integrity": "sha512-/0rgZPEOcZq5CFA4+4n6Q6zk7fi8skHhH2Bcra8R3epoJEYy5PL55LuMazPtPH1oKeRausDV/Omz4BbgFsn1HQ==",
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"prop-types": "^15.7.2",
+				"react-is": "^16.8.0"
+			}
+		},
+		"@types/prop-types": {
+			"version": "15.7.3",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+		},
+		"@types/react": {
+			"version": "16.9.36",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.36.tgz",
+			"integrity": "sha512-mGgUb/Rk/vGx4NCvquRuSH0GHBQKb1OqpGS9cT9lFxlTLHZgkksgI60TuIxubmn7JuCb+sENHhQciqa0npm0AQ==",
+			"requires": {
+				"@types/prop-types": "*",
+				"csstype": "^2.2.0"
+			}
+		},
+		"@types/react-transition-group": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
+			"integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
+			"requires": {
+				"@types/react": "*"
+			}
+		},
+		"clsx": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+			"integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+		},
+		"css-vendor": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+			"integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+			"requires": {
+				"@babel/runtime": "^7.8.3",
+				"is-in-browser": "^1.0.2"
+			}
+		},
+		"csstype": {
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
+			"integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
+		},
+		"dom-helpers": {
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.4.tgz",
+			"integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
+			"requires": {
+				"@babel/runtime": "^7.8.7",
+				"csstype": "^2.6.7"
+			}
+		},
+		"hoist-non-react-statics": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"requires": {
+				"react-is": "^16.7.0"
+			}
+		},
+		"hyphenate-style-name": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
+			"integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+		},
+		"is-in-browser": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+			"integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+		},
+		"jss": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/jss/-/jss-10.2.0.tgz",
+			"integrity": "sha512-WyG2Jm8nEbYHIVx0UIitgS7R1SXwWpQ1p+SHeI2HNrNR/DSEBXR8l0XYqNdVOCvKnFDPwVWVW7EFlhPh0tYA2w==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"csstype": "^2.6.5",
+				"is-in-browser": "^1.1.3",
+				"tiny-warning": "^1.0.2"
+			}
+		},
+		"jss-plugin-camel-case": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.2.0.tgz",
+			"integrity": "sha512-N5RF3TV+ejKfnq1I/wfp4uj8IVgJCRw4LZQyxW6XiYr6qX2CJsrVvF/lxYIkEL/C19Lgso5D7zy1uxlRWJWGjQ==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"hyphenate-style-name": "^1.0.3",
+				"jss": "10.2.0"
+			}
+		},
+		"jss-plugin-default-unit": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.2.0.tgz",
+			"integrity": "sha512-uni8vfNiCUffm+C26+bhEVX9bWiI1f+bzdDJ3hsgRD1cLey5qZ8zVR6IVa2OVWTG7mMN2eOdG2GxpSCOEuG54Q==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"jss": "10.2.0"
+			}
+		},
+		"jss-plugin-global": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.2.0.tgz",
+			"integrity": "sha512-l2Y1sRXnhMgw7Hq0iH8loWaokIdmXSCD6BE9uporzt48K/cEAkiy1Qx7oeuBE5wHahlOeIASZRGQlm09u5ckrA==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"jss": "10.2.0"
+			}
+		},
+		"jss-plugin-nested": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.2.0.tgz",
+			"integrity": "sha512-4pO6fiWMbtEp8eJlBUaS1vg1bFjCBZsN1Kl0mVqX5jdQJ/7hvKWsX2pIKGFIu9eOcyr30Nacy6NxGiAlYJjbFA==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"jss": "10.2.0",
+				"tiny-warning": "^1.0.2"
+			}
+		},
+		"jss-plugin-props-sort": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.2.0.tgz",
+			"integrity": "sha512-ihJwnaFLdyfTz6azGkz3WEwLkrh1p4X8PKBdCYaIsTnbNcCh/aULzxI7PkVjkd2Z/zCVK2CFfw3EE4Wxhwo1XQ==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"jss": "10.2.0"
+			}
+		},
+		"jss-plugin-rule-value-function": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.2.0.tgz",
+			"integrity": "sha512-16Y612DFhOCdMVTQYMxPuGQr7YIxcy6ehrQV408z8njYajc1Qtpc9JVl/wmTJFIYVRKfY9/0HQXSxD3Z3Gn0Hw==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"jss": "10.2.0",
+				"tiny-warning": "^1.0.2"
+			}
+		},
+		"jss-plugin-vendor-prefixer": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.2.0.tgz",
+			"integrity": "sha512-r6HytNgrGPAbW+vrcRtY+nOMLaEwBz8HSDtsuQFU06bAH4+NOK34QRxie4jOepLAmmbpjxWt6f4c8CUFGmiFCA==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"css-vendor": "^2.0.8",
+				"jss": "10.2.0"
+			}
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
 		"moment": {
 			"version": "2.26.0",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
 			"integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"popper.js": {
+			"version": "1.16.1-lts",
+			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+			"integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
+		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
+		},
+		"react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+		},
+		"react-transition-group": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+			"integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+			"requires": {
+				"@babel/runtime": "^7.5.5",
+				"dom-helpers": "^5.0.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2"
+			}
+		},
+		"regenerator-runtime": {
+			"version": "0.13.5",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+		},
+		"tiny-warning": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+			"integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
 		}
 	}
 }

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/package.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/package.json
@@ -4,7 +4,10 @@
     "private": true,
     "dependencies": {
         "@analytics-apim/common-lib": "^1.0.0",
-        "moment": "^2.24.0"
+        "moment": "^2.24.0",
+        "@material-ui/core": "^4.9.10",
+        "@material-ui/icons": "^4.9.1",
+        "@material-ui/lab": "^4.0.0-alpha.49"
     },
     "scripts": {
         "build": "../node_modules/.bin/webpack -p",

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/APIMAlertSummary.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/APIMAlertSummary.jsx
@@ -21,19 +21,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Scrollbars } from 'react-custom-scrollbars';
 import { FormattedMessage } from 'react-intl';
+import Autocomplete from '@material-ui/lab/Autocomplete';
+import FormControl from '@material-ui/core/FormControl';
+import TextField from '@material-ui/core/TextField';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import CustomTable from './CustomTable';
 
 /**
- * Display API Overall Info
+ * Display API Alert Summary
  * @param {any} props @inheritDoc
- * @returns {ReactElement} Render the Api Overall info widget body
+ * @returns {ReactElement} Render the Api Alert Summary widget body
  */
 export default function APIMAlertSummary(props) {
     const {
-        height, apiInfoData, inProgress, themeName,
+        height, alertData, inProgress, themeName, selectedApi, apiList, handleApiChange, limit, handleLimitChange,
     } = props;
     const styles = {
         headingWrapper: {
@@ -54,6 +57,9 @@ export default function APIMAlertSummary(props) {
             margin: 'auto',
             width: '90%',
         },
+        tableWrapper: {
+            paddingTop: 5,
+        },
         paperWrapper: {
             height: '75%',
             width: '95%',
@@ -73,11 +79,17 @@ export default function APIMAlertSummary(props) {
             justifyContent: 'center',
             height,
         },
-        subheading: {
-            textAlign: 'center',
-            margin: 5,
-            fontSize: 14,
-            color: '#b5b5b5',
+        formWrapper: {
+            paddingBottom: 20,
+            paddingLeft: 20,
+        },
+        formControlAutocomplete: {
+            marginRight: 20,
+            marginTop: 15,
+            minWidth: 300,
+        },
+        formControlLimit: {
+            width: '10%',
         },
     };
 
@@ -95,8 +107,41 @@ export default function APIMAlertSummary(props) {
             >
                 <div style={styles.headingWrapper}>
                     <h3 style={styles.heading}>
-                        <FormattedMessage id='alert.summary.heading' defaultMessage='All Alert Summary' />
+                        <FormattedMessage id='widget.heading' defaultMessage='ALERT SUMMARY' />
                     </h3>
+                </div>
+
+                <div style={styles.formWrapper}>
+                    <form noValidate autoComplete='off'>
+                        <FormControl style={styles.formControlAutocomplete}>
+                            <Autocomplete
+                                options={apiList}
+                                getOptionLabel={option => option}
+                                value={selectedApi}
+                                onChange={(event, value) => handleApiChange(value)}
+                                renderInput={params => (
+                                    <TextField
+                                        {...params}
+                                        label={<FormattedMessage id='api.label' defaultMessage='API' />}
+                                        variant='standard'
+                                    />
+                                )}
+                            />
+                        </FormControl>
+                        <FormControl style={styles.formControlLimit}>
+                            <TextField
+                                id='limit-number'
+                                label={<FormattedMessage id='limit' defaultMessage='Limit' />}
+                                value={limit}
+                                onChange={handleLimitChange}
+                                type='number'
+                                InputLabelProps={{
+                                    shrink: true,
+                                }}
+                                margin='normal'
+                            />
+                        </FormControl>
+                    </form>
                 </div>
                 <div>
                     { inProgress ? (
@@ -105,7 +150,7 @@ export default function APIMAlertSummary(props) {
                         </div>
                     ) : (
                         <div>
-                            { apiInfoData.length === 0
+                            { alertData.length === 0
                                 ? (
                                     <div style={styles.dataWrapper}>
                                         <Paper
@@ -128,10 +173,8 @@ export default function APIMAlertSummary(props) {
                                         </Paper>
                                     </div>
                                 ) : (
-                                    <div>
-                                        <div style={{ marginTop: '2%' }}>
-                                            <CustomTable data={apiInfoData} loadingApiInfo={inProgress} />
-                                        </div>
+                                    <div style={styles.tableWrapper}>
+                                        <CustomTable data={alertData} />
                                     </div>
                                 )
                             }
@@ -145,8 +188,12 @@ export default function APIMAlertSummary(props) {
 
 APIMAlertSummary.propTypes = {
     height: PropTypes.string.isRequired,
-    apiInfoData: PropTypes.instanceOf(Object).isRequired,
-    loadingApiInfo: PropTypes.instanceOf(Object).isRequired,
+    alertData: PropTypes.instanceOf(Object).isRequired,
+    apiList: PropTypes.instanceOf(Object).isRequired,
     inProgress: PropTypes.bool.isRequired,
     themeName: PropTypes.string.isRequired,
+    selectedApi: PropTypes.string.isRequired,
+    limit: PropTypes.string.isRequired,
+    handleApiChange: PropTypes.func.isRequired,
+    handleLimitChange: PropTypes.func.isRequired,
 };

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/APIMAlertSummary.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/APIMAlertSummary.jsx
@@ -20,7 +20,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Scrollbars } from 'react-custom-scrollbars';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import FormControl from '@material-ui/core/FormControl';
 import TextField from '@material-ui/core/TextField';
@@ -28,15 +28,16 @@ import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import CustomTable from './CustomTable';
+import Moment from "moment/moment";
 
 /**
  * Display API Alert Summary
  * @param {any} props @inheritDoc
  * @returns {ReactElement} Render the Api Alert Summary widget body
  */
-export default function APIMAlertSummary(props) {
+function APIMAlertSummary(props) {
     const {
-        height, alertData, inProgress, themeName, selectedApi, apiList, handleApiChange, limit, handleLimitChange,
+        height, alertData, inProgress, themeName, selectedApi, apiList, handleApiChange, limit, handleLimitChange, intl,
     } = props;
     const styles = {
         headingWrapper: {
@@ -92,6 +93,16 @@ export default function APIMAlertSummary(props) {
             width: '10%',
         },
     };
+    const tableData = alertData.map((data) => {
+        return {
+            apiname: data.apiname,
+            type: data.type,
+            severity: intl.formatMessage({ id: 'alert.severity.' + data.severity }),
+            severityColor: data.severityColor,
+            details: data.details,
+            time: data.time,
+        };
+    });
 
     return (
         <Scrollbars style={{
@@ -174,7 +185,7 @@ export default function APIMAlertSummary(props) {
                                     </div>
                                 ) : (
                                     <div style={styles.tableWrapper}>
-                                        <CustomTable data={alertData} />
+                                        <CustomTable data={tableData} />
                                     </div>
                                 )
                             }
@@ -196,4 +207,7 @@ APIMAlertSummary.propTypes = {
     limit: PropTypes.string.isRequired,
     handleApiChange: PropTypes.func.isRequired,
     handleLimitChange: PropTypes.func.isRequired,
+    intl: intlShape.isRequired,
 };
+
+export default injectIntl(APIMAlertSummary);

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/APIMAlertSummaryWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/APIMAlertSummaryWidget.jsx
@@ -27,6 +27,7 @@ import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import Widget from '@wso2-dashboards/widget';
+import cloneDeep from 'lodash/cloneDeep';
 import APIMAlertSummary from './APIMAlertSummary';
 
 const darkTheme = createMuiTheme({
@@ -49,6 +50,11 @@ const lightTheme = createMuiTheme({
     },
 });
 
+const queryParamKey = 'alertSummary';
+
+const API_CALLBACK = '-api';
+const ALERT_CALLBACK = '-alert';
+
 /**
  * Language
  * @type {string}
@@ -60,10 +66,8 @@ const language = (navigator.languages && navigator.languages[0]) || navigator.la
  */
 const languageWithoutRegionCode = language.toLowerCase().split(/[_-]+/)[0];
 
-let refreshIntervalId = null;
-
 /**
- * Create react component for the APIM Oerall Api Info widget
+ * Create react component for the APIM Alert Summary widget
  * @class APIMAlertSummaryWidget
  * @extends {Widget}
  */
@@ -85,22 +89,21 @@ class APIMAlertSummaryWidget extends Widget {
                 width: '50%',
                 marginTop: '20%',
             },
-            button: {
-                maxWidth: '30px',
-                maxHeight: '30px',
-                minWidth: '30px',
-                minHeight: '30px',
-            },
         };
 
         this.state = {
             width: this.props.width,
             height: this.props.height,
-            usageData: null,
+            alertData: null,
             refreshInterval: 60000, // 1min
             refreshIntervalId: null,
             localeMessages: null,
             inProgress: true,
+            apiList: [],
+            selectedApi: 'All',
+            timeFrom: null,
+            timeTo: null,
+            limit: 5,
         };
 
         // This will re-size the widget when the glContainer's width is changed.
@@ -111,9 +114,16 @@ class APIMAlertSummaryWidget extends Widget {
             }));
         }
 
-        this.assembleApiInfo = this.assembleApiInfo.bind(this);
-        this.handleApiInfoReceived = this.handleApiInfoReceived.bind(this);
+        this.handlePublisherParameters = this.handlePublisherParameters.bind(this);
+        this.assembleApiAlerts = this.assembleApiAlerts.bind(this);
+        this.handleApiAlertsReceived = this.handleApiAlertsReceived.bind(this);
+        this.assembleApiList = this.assembleApiList.bind(this);
+        this.handleApiListReceived = this.handleApiListReceived.bind(this);
+        this.handleApiChange = this.handleApiChange.bind(this);
         this.loadLocale = this.loadLocale.bind(this);
+        this.setQueryParam = this.setQueryParam.bind(this);
+        this.loadQueryParam = this.loadQueryParam.bind(this);
+        this.handleLimitChange = this.handleLimitChange.bind(this);
     }
 
     componentWillMount() {
@@ -128,15 +138,19 @@ class APIMAlertSummaryWidget extends Widget {
     componentDidMount() {
         const { widgetID } = this.props;
         const { refreshInterval } = this.state;
+        this.loadQueryParam();
+
         super.getWidgetConfiguration(widgetID)
             .then((message) => {
                 // set an interval to periodically retrieve data
                 const refresh = () => {
-                    super.getWidgetChannelManager().unsubscribeWidget(widgetID);
-                    this.assembleApiInfo(message.data.configs.providerConfig);
+                    this.assembleApiAlerts();
                 };
-                refreshIntervalId = setInterval(refresh, refreshInterval);
-                this.assembleApiInfo(message.data.configs.providerConfig);
+                const refreshIntervalId = setInterval(refresh, refreshInterval);
+                this.setState({
+                    providerConfig: message.data.configs.providerConfig,
+                    refreshIntervalId,
+                }, () => super.subscribe(this.handlePublisherParameters));
             })
             .catch((error) => {
                 console.error("Error occurred when loading widget '" + widgetID + "'. " + error);
@@ -148,8 +162,10 @@ class APIMAlertSummaryWidget extends Widget {
 
     componentWillUnmount() {
         const { id } = this.props;
+        const { refreshIntervalId } = this.state;
         clearInterval(refreshIntervalId);
-        super.getWidgetChannelManager().unsubscribeWidget(id);
+        super.getWidgetChannelManager().unsubscribeWidget(id + API_CALLBACK);
+        super.getWidgetChannelManager().unsubscribeWidget(id + ALERT_CALLBACK);
     }
 
     /**
@@ -173,23 +189,95 @@ class APIMAlertSummaryWidget extends Widget {
     }
 
     /**
-     * Retreive the API info for sub rows
+     * Retrieve the limit from query param
+     * @memberof APIMApiUsageWidget
+     * */
+    loadQueryParam() {
+        const { selectedApi } = super.getGlobalState(queryParamKey);
+        let { limit } = super.getGlobalState(queryParamKey);
+        if (!limit || limit < 0) {
+            limit = 5;
+        }
+        this.setQueryParam(selectedApi, limit);
+        this.setState({ selectedApi, limit });
+    }
+
+    /**
+     * Retrieve params from publisher - DateTimeRange
      * @memberof APIMAlertSummaryWidget
      * */
-    assembleApiInfo(dataProviderConfigs) {
+    handlePublisherParameters(receivedMsg) {
+        const queryParam = super.getGlobalState('dtrp');
+        const { sync } = queryParam;
+        const { from, to } = receivedMsg;
+
+        this.setState({
+            timeFrom: from,
+            timeTo: to,
+            inProgress: !sync,
+        }, this.assembleApiList);
+    }
+
+    /**
+     * Retrieve the API list
+     * @memberof APIMAlertSummaryWidget
+     * */
+    assembleApiList() {
         const { id, widgetID: widgetName } = this.props;
-        dataProviderConfigs.configs.config.queryData.queryName = 'infoquery';
+        const { providerConfig } = this.state;
 
-        const timeTo = new Date().getTime();
-        const timeFrom = Moment(timeTo).subtract(7, 'days').toDate().getTime();
-
-        dataProviderConfigs.configs.config.queryData.queryValues = {
-            '{{from}}': timeFrom,
-            '{{to}}': timeTo,
-            '{{per}}': 'day',
-        };
+        const dataProviderConfigs = cloneDeep(providerConfig);
+        dataProviderConfigs.configs.config.queryData.queryName = 'apiquery';
         super.getWidgetChannelManager()
-            .subscribeWidget(id, widgetName, this.handleApiInfoReceived, dataProviderConfigs);
+            .subscribeWidget(id + API_CALLBACK, widgetName, this.handleApiListReceived, dataProviderConfigs);
+    }
+
+    /**
+     * Formats data retrieved from assembleApiList query
+     * @param {object} message - data retrieved
+     * @memberof APIMAlertSummaryWidget
+     * */
+    handleApiListReceived(message) {
+        const { data } = message;
+        let { selectedApi } = { ...this.state };
+
+        if (data && data.length > 0) {
+            let apiList = data.map((dataUnit) => { return dataUnit[0]; });
+            apiList = Array.from(new Set(apiList));
+            apiList.sort((a, b) => { return a.toLowerCase().localeCompare(b.toLowerCase()); });
+            apiList.unshift('All');
+
+            if (!apiList.includes(selectedApi)) {
+                selectedApi = 'All';
+            }
+            this.setState({ apiList, selectedApi }, this.assembleApiAlerts);
+        } else {
+            this.setState({ alertData: [], apiList: [], inProgress: false });
+        }
+    }
+
+    /**
+     * Retrieve the API info for sub rows
+     * @memberof APIMAlertSummaryWidget
+     * */
+    assembleApiAlerts() {
+        const { id, widgetID: widgetName } = this.props;
+        const {
+            timeFrom, timeTo, providerConfig, selectedApi, limit,
+        } = this.state;
+
+        if (timeFrom) {
+            const dataProviderConfigs = cloneDeep(providerConfig);
+            dataProviderConfigs.configs.config.queryData.queryName = 'alertquery';
+            dataProviderConfigs.configs.config.queryData.queryValues = {
+                '{{timeFrom}}': timeFrom,
+                '{{timeTo}}': timeTo,
+                '{{apiName}}': selectedApi !== 'All' ? 'AND apiName == \'' + selectedApi + '\'' : '',
+                '{{limit}}': limit,
+            };
+            super.getWidgetChannelManager()
+                .subscribeWidget(id + ALERT_CALLBACK, widgetName, this.handleApiAlertsReceived, dataProviderConfigs);
+        }
     }
 
     /**
@@ -197,36 +285,79 @@ class APIMAlertSummaryWidget extends Widget {
      * @param {object} message - data retrieved
      * @memberof APIMAlertSummaryWidget
      * */
-    handleApiInfoReceived(message) {
-        const { data, metadata: { names } } = message;
-        const newData = data.map((row) => {
-            const obj = {};
-            for (let j = 0; j < row.length; j++) {
-                obj[names[j]] = row[j];
-            }
-            return obj;
-        });
-        const { id } = this.props;
-        this.setState({ apiInfoData: newData, inProgress: false });
-        super.getWidgetChannelManager().unsubscribeWidget(id);
+    handleApiAlertsReceived(message) {
+        const { data } = message;
+
+        if (data && data.length > 0) {
+            const alertData = data.map((dataUnit) => {
+                return {
+                    apiname: dataUnit[0],
+                    type: dataUnit[1],
+                    severity: dataUnit[2],
+                    details: dataUnit[3],
+                    time: Moment(dataUnit[4]).format('YYYY-MMM-DD hh:mm:ss A'),
+                };
+            });
+            this.setState({ alertData, inProgress: false });
+        } else {
+            this.setState({ alertData: [], inProgress: false });
+        }
+    }
+
+    /**
+     * Handle onChange of selected api
+     * @param {String} value - selected api
+     * @memberof APIMAlertSummaryWidget
+     * */
+    handleApiChange(value) {
+        const { limit } = this.state;
+        this.setQueryParam(value, limit);
+        this.setState({ selectedApi: value, inProgress: true }, this.assembleApiAlerts);
+    }
+
+    /**
+     * Handle limit  Change
+     * @param {Event} event - listened event
+     * @memberof APIMAlertSummaryWidget
+     * */
+    handleLimitChange(event) {
+        const { selectedApi } = this.state;
+        const limit = (event.target.value).replace('-', '').split('.')[0];
+
+        this.setQueryParam(selectedApi, parseInt(limit, 10));
+        if (limit) {
+            this.setState({ inProgress: true, limit }, this.assembleApiAlerts);
+        } else {
+            this.setState({ limit });
+        }
+    }
+
+    /**
+     * Updates query param values
+     * @param {String} selectedApi - selected api
+     * @param {String} limit - limit
+     * @memberof APIMAlertSummaryWidget
+     * */
+    setQueryParam(selectedApi, limit) {
+        super.setGlobalState(queryParamKey, { selectedApi, limit });
     }
 
     /**
      * @inheritDoc
-     * @returns {ReactElement} Render the APIM Api Overall Api Info widget
+     * @returns {ReactElement} Render the APIM Alert Summary widget
      * @memberof APIMAlertSummaryWidget
      */
     render() {
         const {
-            localeMessages, faultyProviderConfig, height, apiInfoData, inProgress,
+            localeMessages, faultyProviderConfig, height, alertData, inProgress, selectedApi, apiList, limit,
         } = this.state;
         const {
             paper, paperWrapper,
         } = this.styles;
         const { muiTheme } = this.props;
         const themeName = muiTheme.name;
-        const apiUsageProps = {
-            themeName, height, apiInfoData, inProgress,
+        const apiAlertProps = {
+            themeName, height, alertData, inProgress, selectedApi, apiList, limit,
         };
 
         return (
@@ -254,15 +385,17 @@ class APIMAlertSummaryWidget extends Widget {
                                     <Typography component='p'>
                                         <FormattedMessage
                                             id='config.error.body'
-                                            defaultMessage={'Cannot fetch provider configuration for APIM Overall '
-                                            + 'Api Info Widget'}
+                                            defaultMessage={'Cannot fetch provider configuration for APIM ALert '
+                                            + 'Summary Widget'}
                                         />
                                     </Typography>
                                 </Paper>
                             </div>
                         ) : (
                             <APIMAlertSummary
-                                {...apiUsageProps}
+                                {...apiAlertProps}
+                                handleApiChange={this.handleApiChange}
+                                handleLimitChange={this.handleLimitChange}
                             />
                         )
                     }

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/CustomTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/CustomTable.jsx
@@ -270,7 +270,16 @@ class CustomTable extends React.Component {
                                                 {n.type}
                                             </TableCell>
                                             <TableCell numeric>
-                                                {n.severity}
+                                                <span style={{
+                                                    fontWeight: 'bold',
+                                                    backgroundColor: n.severityColor,
+                                                    borderRadius: '5px',
+                                                    padding: '5px',
+                                                    verticalAlign: 'center',
+                                                }}
+                                                >
+                                                    {n.severity}
+                                                </span>
                                             </TableCell>
                                             <TableCell>
                                                 {n.details}

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/CustomTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/CustomTable.jsx
@@ -22,7 +22,6 @@ import PropTypes from 'prop-types';
 import { CustomTableToolbar } from '@analytics-apim/common-lib';
 import { FormattedMessage } from 'react-intl';
 import MenuItem from '@material-ui/core/MenuItem';
-import CircularProgress from '@material-ui/core/CircularProgress';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
@@ -45,8 +44,13 @@ function desc(a, b, orderBy) {
     let tempb = b[orderBy];
 
     if (typeof (tempa) === 'string') {
-        tempa = tempa.toLowerCase();
-        tempb = tempb.toLowerCase();
+        if (Moment(tempa).isValid()) {
+            tempa = Moment(tempa).valueOf();
+            tempb = Moment(tempb).valueOf();
+        } else {
+            tempa = tempa.toLowerCase();
+            tempb = tempb.toLowerCase();
+        }
     }
 
     if (tempb < tempa) {
@@ -135,17 +139,6 @@ const styles = theme => ({
     paginationActions: {
         marginLeft: 0,
     },
-    inProgress: {
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-    },
-    noDataMessage: {
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        color: '#888888',
-    },
 });
 
 /**
@@ -206,8 +199,9 @@ class CustomTable extends React.Component {
      * @return {ReactElement} customTable
      */
     render() {
-        const timeFormat = 'YY/DD/MM, HH:mm:ss';
-        const { data, classes, loadingApiInfo, themeName } = this.props;
+        const {
+            data, classes,
+        } = this.props;
         const {
             query, expanded, filterColumn, order, orderBy, rowsPerPage, page,
         } = this.state;
@@ -219,14 +213,14 @@ class CustomTable extends React.Component {
         const emptyRows = rowsPerPage - Math.min(rowsPerPage, tableData.length - page * rowsPerPage);
 
         const menuItems = [
+            <MenuItem value='apiname'>
+                <FormattedMessage id='table.heading.apiname' defaultMessage='API NAME' />
+            </MenuItem>,
             <MenuItem value='type'>
                 <FormattedMessage id='table.heading.type' defaultMessage='ALERT TYPE' />
             </MenuItem>,
             <MenuItem value='severity'>
                 <FormattedMessage id='table.heading.severity' defaultMessage='SEVERITY' />
-            </MenuItem>,
-            <MenuItem value='apiname'>
-                <FormattedMessage id='table.heading.apiname' defaultMessage='API NAME' />
             </MenuItem>,
             <MenuItem value='details'>
                 <FormattedMessage id='table.heading.details' defaultMessage='DETAILS' />
@@ -246,70 +240,55 @@ class CustomTable extends React.Component {
                     handleQueryChange={this.handleQueryChange}
                     menuItems={menuItems}
                 />
-                { loadingApiInfo ? (
-                    <div className={classes.inProgress} style={{ height: rowsPerPage * 49 }}>
-                        <CircularProgress />
-                    </div>
-                ) : (
-                    <div>
-                        {
-                            tableData.length > 0 ? (
-                                <div className={classes.tableWrapper}>
-                                    <Table className={classes.table} aria-labelledby='tableTitle'>
-                                        <CustomTableHead
-                                            order={order}
-                                            orderBy={orderBy}
-                                            onRequestSort={this.handleRequestSort}
-                                        />
-                                        <TableBody>
-                                            {stableSort(tableData, getSorting(order, orderBy))
-                                                .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                                                .map((n) => {
-                                                    return (
-                                                        <TableRow
-                                                            hover
-                                                            tabIndex={-1}
-                                                        >
-                                                            <TableCell component='th' scope='row'>
-                                                                {n.type}
-                                                            </TableCell>
-                                                            <TableCell>
-                                                                {n.severity}
-                                                            </TableCell>
-                                                            <TableCell>
-                                                                {n.apiName}
-                                                            </TableCell>
-                                                            <TableCell>
-                                                                {n.message}
-                                                            </TableCell>
-                                                            <TableCell>
-                                                                {Moment(n.alertTimestamp).format(timeFormat)}
-                                                            </TableCell>
-                                                        </TableRow>
-                                                    );
-                                                })}
-                                            {emptyRows > 0 && (
-                                                <TableRow style={{ height: 49 * emptyRows }}>
-                                                    <TableCell colSpan={6} />
-                                                </TableRow>
-                                            )}
-                                        </TableBody>
-                                    </Table>
-                                </div>
-                            ) : (
-                                <div
-                                    className={classes.noDataMessage}
-                                    style={{ height: (rowsPerPage + 1) * 49 }}
-                                >
-                                    <FormattedMessage
-                                        id='nodata.error.body'
-                                        defaultMessage='No data available for the selected options.'
-                                    />
-                                </div>
-                            )
-                        }
-                    </div>
-                )}
+                <div className={classes.tableWrapper}>
+                    <Table className={classes.table} aria-labelledby='tableTitle'>
+                        <CustomTableHead
+                            order={order}
+                            orderBy={orderBy}
+                            onRequestSort={this.handleRequestSort}
+                        />
+                        <colgroup>
+                            <col style={{ width: '20%' }} />
+                            <col style={{ width: '15%' }} />
+                            <col style={{ width: '10%' }} />
+                            <col style={{ width: '35%' }} />
+                            <col style={{ width: '20%' }} />
+                        </colgroup>
+                        <TableBody>
+                            {stableSort(tableData, getSorting(order, orderBy))
+                                .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                                .map((n) => {
+                                    return (
+                                        <TableRow
+                                            hover
+                                            tabIndex={-1}
+                                        >
+                                            <TableCell>
+                                                {n.apiname}
+                                            </TableCell>
+                                            <TableCell component='th' scope='row'>
+                                                {n.type}
+                                            </TableCell>
+                                            <TableCell numeric>
+                                                {n.severity}
+                                            </TableCell>
+                                            <TableCell>
+                                                {n.details}
+                                            </TableCell>
+                                            <TableCell>
+                                                {n.time}
+                                            </TableCell>
+                                        </TableRow>
+                                    );
+                                })}
+                            {emptyRows > 0 && (
+                                <TableRow style={{ height: 49 * emptyRows }}>
+                                    <TableCell colSpan={6} />
+                                </TableRow>
+                            )}
+                        </TableBody>
+                    </Table>
+                </div>
                 <TablePagination
                     rowsPerPageOptions={[5, 10, 20, 25, 50, 100]}
                     component='div'
@@ -344,8 +323,6 @@ class CustomTable extends React.Component {
 CustomTable.propTypes = {
     classes: PropTypes.instanceOf(Object).isRequired,
     data: PropTypes.instanceOf(Object).isRequired,
-    loadingApiInfo: PropTypes.instanceOf(Object).isRequired,
-    themeName: PropTypes.string.isRequired,
 };
 
 export default withStyles(styles)(CustomTable);

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/CustomTableHead.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/CustomTableHead.jsx
@@ -28,19 +28,19 @@ import TableSortLabel from '@material-ui/core/TableSortLabel';
 
 const rows = [
     {
+        id: 'apiname', numeric: false, disablePadding: false, label: 'table.heading.apiname',
+    },
+    {
         id: 'type', numeric: false, disablePadding: false, label: 'table.heading.type',
     },
     {
         id: 'severity', numeric: true, disablePadding: false, label: 'table.heading.severity',
     },
     {
-        id: 'apiname', numeric: true, disablePadding: false, label: 'table.heading.apiname',
+        id: 'details', numeric: false, disablePadding: false, label: 'table.heading.details',
     },
     {
-        id: 'details', numeric: true, disablePadding: false, label: 'table.heading.details',
-    },
-    {
-        id: 'time', numeric: true, disablePadding: false, label: 'table.heading.time',
+        id: 'time', numeric: false, disablePadding: false, label: 'table.heading.time',
     },
 ];
 

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/resources/locales/en.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/resources/locales/en.json
@@ -1,17 +1,15 @@
 {
-  "config.error.body": "Cannot fetch provider configuration for APIM Overall Api Info widget",
+  "api.label": "API",
+  "config.error.body": "Cannot fetch provider configuration for APIM Alert Summary widget",
   "config.error.heading": "Configuration Error !",
-  "createdBy.label": "API Created By",
+  "limit": "Limit",
   "nodata.error.body": "No data available for the selected options",
   "nodata.error.heading": "No Data Available !",
-  "api.info.heading": "OVERALL API INFO",
-  "api.info.subheading": "(Last 7 Days)",
   "table.heading.apiname": "API NAME",
-  "table.heading.method": "METHOD",
-  "table.heading.success": "SUCCESS HITS",
-  "table.heading.error4xx": "ERROR 4XX",
-  "table.heading.error5xx": "ERROR 5XX",
-  "table.heading.errorFaulty": "FAULTY HITS",
-  "table.heading.errorThrottled": "THROTTLED HIT",
-  "sort.label.title": "Sort"
+  "table.heading.details": "DETAILS",
+  "table.heading.time": "ALERT TIME",
+  "table.heading.type": "ALERT TYPE",
+  "table.heading.severity": "SEVERITY",
+  "sort.label.title": "Sort",
+  "widget.heading" : "ALERT SUMMARY"
 }

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/resources/locales/en.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/resources/locales/en.json
@@ -1,4 +1,7 @@
 {
+  "alert.severity.mild": "Mild",
+  "alert.severity.moderate": "Moderate",
+  "alert.severity.severe": "Severe",
   "api.label": "API",
   "config.error.body": "Cannot fetch provider configuration for APIM Alert Summary widget",
   "config.error.heading": "Configuration Error !",

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/resources/widgetConf.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummary/src/resources/widgetConf.json
@@ -10,9 +10,10 @@
       "configs": {
         "type": "SiddhiStoreDataProvider",
         "config": {
-          "siddhiApp": "@App:name('APIM_alert_SUMMARY')\n@store(type='rdbms' , datasource= 'AM_DB')\ndefine table AM_API(API_ID int,API_PROVIDER string,API_NAME string,API_VERSION string,CONTEXT string,CONTEXT_TEMPLATE string,API_TIER string,CREATED_BY string,CREATED_TIME string,UPDATED_BY string,UPDATED_TIME string);\n@store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB', field.length = 'message:3000')\ndefine table ApimAllAlert (type string, tenantDomain string, message string, severity int, alertTimestamp long, apiName string);",
+          "siddhiApp": "@App:name('APIM_alert_SUMMARY') @store(type='rdbms' , datasource= 'AM_DB') define table AM_API(API_ID int,API_PROVIDER string,API_NAME string,API_VERSION string,CONTEXT string,CONTEXT_TEMPLATE string,API_TIER string,CREATED_BY string,CREATED_TIME string,UPDATED_BY string,UPDATED_TIME string); @store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB', field.length = 'message:3000') define table ApimAllAlert (type string, tenantDomain string, message string, severity int, alertTimestamp long, apiName string);",
           "queryData": {
-            "infoquery": "from ApimAllAlert on tenantDomain=='{{tenantDomain}}' select apiName, type, severity, alertTimestamp, message"
+            "apiquery": "from AM_API on {{contextContainsCondition}} select API_NAME;",
+            "alertquery": "from ApimAllAlert on tenantDomain=='{{tenantDomain}}' AND alertTimestamp >= {{timeFrom}}L AND alertTimestamp <= {{timeTo}}L {{apiName}} select apiName, type, severity, message, alertTimestamp order by alertTimestamp desc limit {{limit}}"
           },
           "publishingInterval": 60
         }

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/package-lock.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/package-lock.json
@@ -105,6 +105,11 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
+		"moment": {
+			"version": "2.26.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+			"integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/package.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/package.json
@@ -4,7 +4,8 @@
     "private": true,
     "dependencies": {
         "@analytics-apim/common-lib": "^1.0.0",
-        "victory": "^31.0.2"
+        "victory": "^31.0.2",
+        "moment": "^2.24.0"
     },
     "scripts": {
         "build": "../node_modules/.bin/webpack -p",

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/APIMAlertSummaryByAPIs.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/APIMAlertSummaryByAPIs.jsx
@@ -52,13 +52,13 @@ const lightTheme = createMuiTheme({
 });
 
 /**
- * React Component for Top Throttled Out Apis widget body
+ * React Component for APIM Alert Summary By APIs widget body
  * @param {any} props @inheritDoc
- * @returns {ReactElement} Render the Top Throttled Out Apis widget body
+ * @returns {ReactElement} Render the APIM Alert Summary By APIs widget body
  */
 export default function APIMAlertSummaryByAPIs(props) {
     const {
-        themeName, height, limit, throttledData, handleChange, inProgress, width, handleOnClickAPI,
+        themeName, height, limit, alertData, handleChange, inProgress, width, handleOnClickAPI,
     } = props;
     const fontSize = width < 1000 ? 16 : 18;
     const styles = {
@@ -132,7 +132,7 @@ export default function APIMAlertSummaryByAPIs(props) {
         },
     };
 
-    const { pieChartData, legendData } = Utils.summarizePieData(throttledData, 'apiName', 'count');
+    const { pieChartData, legendData } = Utils.summarizePieData(alertData, 'apiname', 'count');
     return (
         <MuiThemeProvider
             theme={themeName === 'dark' ? darkTheme : lightTheme}
@@ -150,7 +150,7 @@ export default function APIMAlertSummaryByAPIs(props) {
                 >
                     <div style={styles.headingWrapper}>
                         <h3 style={styles.heading}>
-                            <FormattedMessage id='widget.heading' defaultMessage='Top Alerts by API' />
+                            <FormattedMessage id='widget.heading' defaultMessage='TOP API BY ALERTS' />
                         </h3>
                     </div>
                     <div style={styles.formWrapper}>
@@ -176,7 +176,7 @@ export default function APIMAlertSummaryByAPIs(props) {
                             </div>
                         ) : (
                             <div>
-                                { !throttledData || throttledData.length === 0 ? (
+                                { !alertData || alertData.length === 0 ? (
                                     <div style={styles.paperWrapper}>
                                         <Paper
                                             elevation={1}
@@ -230,19 +230,19 @@ export default function APIMAlertSummaryByAPIs(props) {
                                                     theme={VictoryTheme.material}
                                                     colorScale={colorScale}
                                                     data={pieChartData}
-                                                    x={d => d.apiName}
+                                                    x={d => d.apiname}
                                                     y={d => d.count}
-                                                    labels={d => `${d.apiName} : ${((d.count
+                                                    labels={d => `${d.apiname} : ${((d.count
                                                         / (sumBy(pieChartData, o => o.count))) * 100)
                                                         .toFixed(2)}%`}
                                                     events={[
                                                         {
                                                             target: 'data',
                                                             eventHandlers: {
-                                                                onClick: () => {
+                                                                onClick: (e) => {
                                                                     return [{
                                                                         mutation: (val) => {
-                                                                            handleOnClickAPI(val.datum);
+                                                                            handleOnClickAPI(e, val.datum);
                                                                         },
                                                                     }];
                                                                 },
@@ -254,8 +254,8 @@ export default function APIMAlertSummaryByAPIs(props) {
                                         </div>
                                         <div style={styles.tableDiv}>
                                             <CustomTable
-                                                data={throttledData}
-                                                onClickTableRow={e => handleOnClickAPI(e)}
+                                                data={alertData}
+                                                onClickTableRow={(e, v) => handleOnClickAPI(e, v)}
                                             />
                                         </div>
                                     </div>
@@ -274,7 +274,7 @@ APIMAlertSummaryByAPIs.propTypes = {
     height: PropTypes.string.isRequired,
     width: PropTypes.string.isRequired,
     limit: PropTypes.string.isRequired,
-    throttledData: PropTypes.instanceOf(Object).isRequired,
+    alertData: PropTypes.instanceOf(Object).isRequired,
     handleChange: PropTypes.func.isRequired,
     handleOnClickAPI: PropTypes.func.isRequired,
     inProgress: PropTypes.bool.isRequired,

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/APIMAlertSummaryByAPIs.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/APIMAlertSummaryByAPIs.jsx
@@ -127,8 +127,13 @@ export default function APIMAlertSummaryByAPIs(props) {
             textAlign: 'center',
             fontWeight: 'normal',
             letterSpacing: 1.5,
-            paddingBottom: '10px',
             marginTop: 0,
+        },
+        subheading: {
+            textAlign: 'center',
+            margin: 5,
+            fontSize: 14,
+            color: '#b5b5b5',
         },
     };
 
@@ -150,8 +155,11 @@ export default function APIMAlertSummaryByAPIs(props) {
                 >
                     <div style={styles.headingWrapper}>
                         <h3 style={styles.heading}>
-                            <FormattedMessage id='widget.heading' defaultMessage='TOP API BY ALERTS' />
+                            <FormattedMessage id='widget.heading' defaultMessage='TOP API BY ALERT COUNT' />
                         </h3>
+                        <p style={styles.subheading}>
+                            <FormattedMessage id='api.info.subheading' defaultMessage='(Last 7 Days)' />
+                        </p>
                     </div>
                     <div style={styles.formWrapper}>
                         <form style={styles.form} noValidate autoComplete='off'>

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/CustomTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/CustomTable.jsx
@@ -151,7 +151,7 @@ class CustomTable extends React.Component {
             tableData: [],
             page: 0,
             rowsPerPage: 5,
-            orderBy: 'throttledcount',
+            orderBy: 'count',
             order: 'desc',
             expanded: false,
             filterColumn: 'apiname',
@@ -208,8 +208,8 @@ class CustomTable extends React.Component {
             <MenuItem value='apiname'>
                 <FormattedMessage id='table.heading.apiname' defaultMessage='API NAME' />
             </MenuItem>,
-            <MenuItem value='alertCount'>
-                <FormattedMessage id='table.heading.alertCount' defaultMessage='Alert Count' />
+            <MenuItem value='count'>
+                <FormattedMessage id='table.heading.count' defaultMessage='COUNT' />
             </MenuItem>,
         ];
         return (
@@ -246,8 +246,8 @@ class CustomTable extends React.Component {
                                             key={n.id}
                                         >
                                             <TableCell component='th' scope='row'>
-                                                <Link href='#' onClick={() => onClickTableRow(n)} color='inherit'>
-                                                    {n.apiName}
+                                                <Link href='#' onClick={e => onClickTableRow(e, n)} color='inherit'>
+                                                    {n.apiname}
                                                 </Link>
                                             </TableCell>
                                             <TableCell component='th' scope='row' numeric>

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/CustomTableHead.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/CustomTableHead.jsx
@@ -31,7 +31,7 @@ const rows = [
         id: 'apiname', numeric: false, disablePadding: false, label: 'table.heading.apiname',
     },
     {
-        id: 'alertCount', numeric: true, disablePadding: false, label: 'table.heading.alertCount',
+        id: 'count', numeric: true, disablePadding: false, label: 'table.heading.count',
     },
 ];
 

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/resources/locales/en.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/resources/locales/en.json
@@ -10,5 +10,6 @@
   "sort.label.title": "Sort",
   "table.heading.apiname": "API NAME",
   "table.heading.count": "COUNT",
-  "widget.heading": "TOP API BY ALERTS"
+  "widget.heading": "TOP API BY ALERT COUNT",
+  "widget.subheading": "(Last 7 Days)"
 }

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/resources/locales/en.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/resources/locales/en.json
@@ -1,5 +1,5 @@
 {
-  "config.error.body": "Cannot fetch provider configuration for APIM Top Throttled Out Apis widget",
+  "config.error.body": "Cannot fetch provider configuration for APIM Alert Summary By APIs widget",
   "config.error.heading": "Configuration Error !",
   "filter.column.menu.heading": "Column Name",
   "filter.label.title": "Filter By",
@@ -9,4 +9,6 @@
   "nodata.error.body": "No data available for the selected options.",
   "sort.label.title": "Sort",
   "table.heading.apiname": "API NAME",
+  "table.heading.count": "COUNT",
+  "widget.heading": "TOP API BY ALERTS"
 }

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/resources/widgetConf.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/resources/widgetConf.json
@@ -4,7 +4,8 @@
   "thumbnailURL": "",
   "configs": {
     "pubsub": {
-      "types": ["subscriber"]
+      "types": ["subscriber", "publisher"],
+      "publisherWidgetOutputs": ["selectedApi"]
     },
     "providerConfig" : {
       "configs": {
@@ -12,7 +13,7 @@
         "config": {
           "siddhiApp": "@App:name('APIM_alert_SUMMARY')\n@store(type='rdbms' , datasource= 'AM_DB')\ndefine table AM_API(API_ID int,API_PROVIDER string,API_NAME string,API_VERSION string,CONTEXT string,CONTEXT_TEMPLATE string,API_TIER string,CREATED_BY string,CREATED_TIME string,UPDATED_BY string,UPDATED_TIME string);\n@store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB', field.length = 'message:3000')\ndefine table ApimAllAlert (type string, tenantDomain string, message string, severity int, alertTimestamp long, apiName string);",
           "queryData": {
-            "query": "from ApimAllAlert on tenantDomain=='{{tenantDomain}}' select apiName, count() as count group by apiName order by count desc"
+            "query": "from ApimAllAlert on tenantDomain=='{{tenantDomain}}' AND alertTimestamp >= {{timeFrom}}L AND alertTimestamp <= {{timeTo}}L select apiName, count() as count group by apiName order by count desc limit {{limit}}"
           },
           "publishingInterval": 360000
         }
@@ -41,11 +42,15 @@
       },
       {
         "id": "drillDown",
-        "title": "API Faults Page",
+        "title": "Drill Down to Alert Summary",
         "type": {
-          "name": "TEXT"
-        },
-        "defaultValue": "api-faults"
+        "name": "BOOLEAN",
+        "possibleValues": [
+          true,
+          false
+        ]
+      },
+        "defaultValue": true
       }
     ]
 

--- a/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/resources/widgetConf.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMAlertSummaryByAPIs/src/resources/widgetConf.json
@@ -4,7 +4,7 @@
   "thumbnailURL": "",
   "configs": {
     "pubsub": {
-      "types": ["subscriber", "publisher"],
+      "types": ["publisher"],
       "publisherWidgetOutputs": ["selectedApi"]
     },
     "providerConfig" : {
@@ -38,7 +38,7 @@
         "type": {
           "name": "TEXT"
         },
-        "defaultValue": "Top Alerts by APIs"
+        "defaultValue": "Top API by Alerts"
       },
       {
         "id": "drillDown",

--- a/components/org.wso2.analytics.apim.widgets/APIMApiAvailability/src/resources/locales/en.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiAvailability/src/resources/locales/en.json
@@ -1,9 +1,8 @@
 {
-  "chart.heading": "API AVAILABILITY :",
   "chart.helper.text": "Please note that API availability is accurately shown only when alerts are enabled. If alerts are disabled, the chart will show 100% availability.",
   "config.error.body": "Cannot fetch provider configuration for APIM Api Availability widget",
   "config.error.heading": "Configuration Error !",
   "nodata.error.body": "No data available for the selected options",
   "nodata.error.heading": "No Data Available !",
-  "widget.heading": "API AVAILABILITY"
+  "widget.heading": "API AVAILABILITY SUMMARY"
 }

--- a/components/org.wso2.analytics.apim.widgets/ApiAvailability/.eslintrc.js
+++ b/components/org.wso2.analytics.apim.widgets/ApiAvailability/.eslintrc.js
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+module.exports = {
+    parser: 'babel-eslint', // Default parser throws unexpected token error while the syntax is correct
+    parserOptions: {
+        ecmaVersion: 6,
+        ecmaFeatures: {
+            jsx: true,
+            modules: true,
+        },
+    },
+    env: {
+        browser: true,
+        es6: true,
+        jest: true
+    },
+    extends: 'airbnb',
+    rules: {
+        'max-len': ['error', 120],
+        'require-jsdoc': [
+            'warn',
+            {
+                require: {
+                    FunctionDeclaration: true,
+                    MethodDefinition: true,
+                    ClassDeclaration: true,
+                },
+            },
+        ],
+        'valid-jsdoc': [
+            'warn',
+            {
+                requireReturn: false,
+                requireReturnDescription: false,
+            },
+        ],
+        indent: ['error', 4, { SwitchCase: 1 }],
+        'import/no-extraneous-dependencies': [
+            'off',
+            {
+                devDependencies: false,
+                optionalDependencies: false,
+                peerDependencies: false,
+            },
+        ],
+        'import/no-unresolved': ['off'],
+        'import/extensions': ['off'],
+        'import/no-named-as-default': ['off'],
+        'import/no-named-as-default-member': ['off'],
+        'no-underscore-dangle': 0,
+        'no-restricted-syntax': ['off'],
+        'no-restricted-globals': ['off'],
+        'no-plusplus': ['off'],
+        'no-param-reassign': 0,
+        'class-methods-use-this': ['off'],
+        'arrow-body-style': 'off',
+        'prefer-template': 'off',
+        'jsx-a11y/no-static-element-interactions': 'off',
+        'jsx-a11y/no-noninteractive-element-interactions': 'off',
+        'jsx-a11y/anchor-is-valid': 'off', // Due to using React-Router Link components
+        'react/jsx-indent': ['error', 4],
+        'react/jsx-indent-props': ['error', 4],
+        'react/no-did-mount-set-state': ['off'], // Validity of this rule is questionable with react 16.3.0 onwards,
+        // until this (https://github.com/yannickcr/eslint-plugin-react/issues/1754) issue resolved
+        'no-mixed-operators': ['error'],
+        'jsx-quotes': ['error', 'prefer-single'],
+        'no-else-return': 'off',
+        'no-unused-vars': ['error'],
+    },
+    plugins: ['react'],
+};

--- a/components/org.wso2.analytics.apim.widgets/ApiAvailability/package-lock.json
+++ b/components/org.wso2.analytics.apim.widgets/ApiAvailability/package-lock.json
@@ -1,0 +1,1589 @@
+{
+    "name": "api-availability",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@analytics-apim/common-lib": {
+            "version": "1.0.0",
+            "requires": {
+                "short-number": "^1.0.7"
+            },
+            "dependencies": {
+                "@babel/cli": {
+                    "version": "7.7.4",
+                    "bundled": true,
+                    "requires": {
+                        "chokidar": "^2.1.8",
+                        "commander": "^4.0.1",
+                        "convert-source-map": "^1.1.0",
+                        "fs-readdir-recursive": "^1.1.0",
+                        "glob": "^7.0.0",
+                        "lodash": "^4.17.13",
+                        "make-dir": "^2.1.0",
+                        "slash": "^2.0.0",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "anymatch": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
+                    },
+                    "dependencies": {
+                        "normalize-path": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "remove-trailing-separator": "^1.0.1"
+                            }
+                        }
+                    }
+                },
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "bundled": true
+                },
+                "arr-flatten": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "arr-union": {
+                    "version": "3.1.0",
+                    "bundled": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "bundled": true
+                },
+                "assign-symbols": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "async-each": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "optional": true
+                },
+                "atob": {
+                    "version": "2.1.2",
+                    "bundled": true
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "base": {
+                    "version": "0.11.2",
+                    "bundled": true,
+                    "requires": {
+                        "cache-base": "^1.0.1",
+                        "class-utils": "^0.3.5",
+                        "component-emitter": "^1.2.1",
+                        "define-property": "^1.0.0",
+                        "isobject": "^3.0.1",
+                        "mixin-deep": "^1.2.0",
+                        "pascalcase": "^0.1.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^1.0.0",
+                                "is-data-descriptor": "^1.0.0",
+                                "kind-of": "^6.0.2"
+                            }
+                        }
+                    }
+                },
+                "binary-extensions": {
+                    "version": "1.13.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "cache-base": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "collection-visit": "^1.0.0",
+                        "component-emitter": "^1.2.1",
+                        "get-value": "^2.0.6",
+                        "has-value": "^1.0.0",
+                        "isobject": "^3.0.1",
+                        "set-value": "^2.0.0",
+                        "to-object-path": "^0.3.0",
+                        "union-value": "^1.0.0",
+                        "unset-value": "^1.0.0"
+                    }
+                },
+                "chokidar": {
+                    "version": "2.1.8",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
+                    }
+                },
+                "class-utils": {
+                    "version": "0.3.6",
+                    "bundled": true,
+                    "requires": {
+                        "arr-union": "^3.1.0",
+                        "define-property": "^0.2.5",
+                        "isobject": "^3.0.0",
+                        "static-extend": "^0.1.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "bundled": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "collection-visit": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "map-visit": "^1.0.0",
+                        "object-visit": "^1.0.0"
+                    }
+                },
+                "commander": {
+                    "version": "4.0.1",
+                    "bundled": true
+                },
+                "component-emitter": {
+                    "version": "1.3.0",
+                    "bundled": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "convert-source-map": {
+                    "version": "1.7.0",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.1"
+                    }
+                },
+                "copy-descriptor": {
+                    "version": "0.1.1",
+                    "bundled": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "bundled": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "decode-uri-component": {
+                    "version": "0.2.0",
+                    "bundled": true
+                },
+                "define-property": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.2",
+                        "isobject": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "is-accessor-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^1.0.0",
+                                "is-data-descriptor": "^1.0.0",
+                                "kind-of": "^6.0.2"
+                            }
+                        }
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "bundled": true,
+                    "requires": {
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "bundled": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "extend-shallow": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "is-extendable": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "is-plain-object": "^2.0.4"
+                            }
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^1.0.0",
+                                "is-data-descriptor": "^1.0.0",
+                                "kind-of": "^6.0.2"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "for-in": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "fragment-cache": {
+                    "version": "0.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "map-cache": "^0.2.2"
+                    }
+                },
+                "fs-readdir-recursive": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "fsevents": {
+                    "version": "1.2.9",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "nan": "^2.12.1",
+                        "node-pre-gyp": "^0.12.0"
+                    },
+                    "dependencies": {
+                        "abbrev": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "bundled": true
+                        },
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "are-we-there-yet": {
+                            "version": "1.1.5",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "delegates": "^1.0.0",
+                                "readable-stream": "^2.0.6"
+                            }
+                        },
+                        "balanced-match": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "brace-expansion": {
+                            "version": "1.1.11",
+                            "bundled": true,
+                            "requires": {
+                                "balanced-match": "^1.0.0",
+                                "concat-map": "0.0.1"
+                            }
+                        },
+                        "chownr": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "code-point-at": {
+                            "version": "1.1.0",
+                            "bundled": true
+                        },
+                        "concat-map": {
+                            "version": "0.0.1",
+                            "bundled": true
+                        },
+                        "console-control-strings": {
+                            "version": "1.1.0",
+                            "bundled": true
+                        },
+                        "core-util-is": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "debug": {
+                            "version": "4.1.1",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "ms": "^2.1.1"
+                            }
+                        },
+                        "deep-extend": {
+                            "version": "0.6.0",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "delegates": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "detect-libc": {
+                            "version": "1.0.3",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "fs-minipass": {
+                            "version": "1.2.5",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "minipass": "^2.2.1"
+                            }
+                        },
+                        "fs.realpath": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "gauge": {
+                            "version": "2.7.4",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "aproba": "^1.0.3",
+                                "console-control-strings": "^1.0.0",
+                                "has-unicode": "^2.0.0",
+                                "object-assign": "^4.1.0",
+                                "signal-exit": "^3.0.0",
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.1",
+                                "wide-align": "^1.1.0"
+                            }
+                        },
+                        "glob": {
+                            "version": "7.1.3",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
+                            }
+                        },
+                        "has-unicode": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "iconv-lite": {
+                            "version": "0.4.24",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "safer-buffer": ">= 2.1.2 < 3"
+                            }
+                        },
+                        "ignore-walk": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "minimatch": "^3.0.4"
+                            }
+                        },
+                        "inflight": {
+                            "version": "1.0.6",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "once": "^1.3.0",
+                                "wrappy": "1"
+                            }
+                        },
+                        "inherits": {
+                            "version": "2.0.3",
+                            "bundled": true
+                        },
+                        "ini": {
+                            "version": "1.3.5",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "number-is-nan": "^1.0.0"
+                            }
+                        },
+                        "isarray": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "minimatch": {
+                            "version": "3.0.4",
+                            "bundled": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        },
+                        "minimist": {
+                            "version": "0.0.8",
+                            "bundled": true
+                        },
+                        "minipass": {
+                            "version": "2.3.5",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
+                            }
+                        },
+                        "minizlib": {
+                            "version": "1.2.1",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "minipass": "^2.2.1"
+                            }
+                        },
+                        "mkdirp": {
+                            "version": "0.5.1",
+                            "bundled": true,
+                            "requires": {
+                                "minimist": "0.0.8"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "needle": {
+                            "version": "2.3.0",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "debug": "^4.1.0",
+                                "iconv-lite": "^0.4.4",
+                                "sax": "^1.2.4"
+                            }
+                        },
+                        "node-pre-gyp": {
+                            "version": "0.12.0",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "detect-libc": "^1.0.2",
+                                "mkdirp": "^0.5.1",
+                                "needle": "^2.2.1",
+                                "nopt": "^4.0.1",
+                                "npm-packlist": "^1.1.6",
+                                "npmlog": "^4.0.2",
+                                "rc": "^1.2.7",
+                                "rimraf": "^2.6.1",
+                                "semver": "^5.3.0",
+                                "tar": "^4"
+                            }
+                        },
+                        "nopt": {
+                            "version": "4.0.1",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "abbrev": "1",
+                                "osenv": "^0.1.4"
+                            }
+                        },
+                        "npm-bundled": {
+                            "version": "1.0.6",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "npm-packlist": {
+                            "version": "1.4.1",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "ignore-walk": "^3.0.1",
+                                "npm-bundled": "^1.0.1"
+                            }
+                        },
+                        "npmlog": {
+                            "version": "4.1.2",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "are-we-there-yet": "~1.1.2",
+                                "console-control-strings": "~1.1.0",
+                                "gauge": "~2.7.3",
+                                "set-blocking": "~2.0.0"
+                            }
+                        },
+                        "number-is-nan": {
+                            "version": "1.0.1",
+                            "bundled": true
+                        },
+                        "object-assign": {
+                            "version": "4.1.1",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "once": {
+                            "version": "1.4.0",
+                            "bundled": true,
+                            "requires": {
+                                "wrappy": "1"
+                            }
+                        },
+                        "os-homedir": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "os-tmpdir": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "osenv": {
+                            "version": "0.1.5",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "os-homedir": "^1.0.0",
+                                "os-tmpdir": "^1.0.0"
+                            }
+                        },
+                        "path-is-absolute": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "process-nextick-args": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "rc": {
+                            "version": "1.2.8",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "deep-extend": "^0.6.0",
+                                "ini": "~1.3.0",
+                                "minimist": "^1.2.0",
+                                "strip-json-comments": "~2.0.1"
+                            },
+                            "dependencies": {
+                                "minimist": {
+                                    "version": "1.2.0",
+                                    "bundled": true,
+                                    "optional": true
+                                }
+                            }
+                        },
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "rimraf": {
+                            "version": "2.6.3",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "glob": "^7.1.3"
+                            }
+                        },
+                        "safe-buffer": {
+                            "version": "5.1.2",
+                            "bundled": true
+                        },
+                        "safer-buffer": {
+                            "version": "2.1.2",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "sax": {
+                            "version": "1.2.4",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "semver": {
+                            "version": "5.7.0",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "set-blocking": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "signal-exit": {
+                            "version": "3.0.2",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "ansi-regex": "^2.0.0"
+                            }
+                        },
+                        "strip-json-comments": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "tar": {
+                            "version": "4.4.8",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "chownr": "^1.1.1",
+                                "fs-minipass": "^1.2.5",
+                                "minipass": "^2.3.4",
+                                "minizlib": "^1.1.1",
+                                "mkdirp": "^0.5.0",
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.2"
+                            }
+                        },
+                        "util-deprecate": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "wide-align": {
+                            "version": "1.1.3",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "string-width": "^1.0.2 || 2"
+                            }
+                        },
+                        "wrappy": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        },
+                        "yallist": {
+                            "version": "3.0.3",
+                            "bundled": true
+                        }
+                    }
+                },
+                "get-value": {
+                    "version": "2.0.6",
+                    "bundled": true
+                },
+                "glob": {
+                    "version": "7.1.6",
+                    "bundled": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "glob-parent": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "is-glob": {
+                            "version": "3.1.0",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "is-extglob": "^2.1.0"
+                            }
+                        }
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.3",
+                    "bundled": true,
+                    "optional": true
+                },
+                "has-value": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "get-value": "^2.0.6",
+                        "has-values": "^1.0.0",
+                        "isobject": "^3.0.0"
+                    }
+                },
+                "has-values": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "kind-of": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.4",
+                    "bundled": true
+                },
+                "is-accessor-descriptor": {
+                    "version": "0.1.6",
+                    "bundled": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "bundled": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "is-binary-path": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "binary-extensions": "^1.0.0"
+                    }
+                },
+                "is-buffer": {
+                    "version": "1.1.6",
+                    "bundled": true
+                },
+                "is-data-descriptor": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "bundled": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "bundled": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "is-extendable": {
+                    "version": "0.1.1",
+                    "bundled": true
+                },
+                "is-extglob": {
+                    "version": "2.1.1",
+                    "bundled": true
+                },
+                "is-glob": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "bundled": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "is-plain-object": {
+                    "version": "2.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "isobject": "^3.0.1"
+                    }
+                },
+                "is-windows": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "bundled": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "bundled": true
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "bundled": true
+                },
+                "make-dir": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "map-cache": {
+                    "version": "0.2.2",
+                    "bundled": true
+                },
+                "map-visit": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "object-visit": "^1.0.0"
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "bundled": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "mixin-deep": {
+                    "version": "1.3.2",
+                    "bundled": true,
+                    "requires": {
+                        "for-in": "^1.0.2",
+                        "is-extendable": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "is-extendable": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "is-plain-object": "^2.0.4"
+                            }
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "nan": {
+                    "version": "2.14.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "nanomatch": {
+                    "version": "1.2.13",
+                    "bundled": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "fragment-cache": "^0.2.1",
+                        "is-windows": "^1.0.2",
+                        "kind-of": "^6.0.2",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    }
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "object-copy": {
+                    "version": "0.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "copy-descriptor": "^0.1.0",
+                        "define-property": "^0.2.5",
+                        "kind-of": "^3.0.3"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "bundled": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "bundled": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "object-visit": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "isobject": "^3.0.0"
+                    }
+                },
+                "object.pick": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "isobject": "^3.0.1"
+                    }
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "pascalcase": {
+                    "version": "0.1.1",
+                    "bundled": true
+                },
+                "path-dirname": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "bundled": true
+                },
+                "posix-character-classes": {
+                    "version": "0.1.1",
+                    "bundled": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "readdirp": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "micromatch": "^3.1.10",
+                        "readable-stream": "^2.0.2"
+                    }
+                },
+                "regex-not": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "extend-shallow": "^3.0.2",
+                        "safe-regex": "^1.1.0"
+                    }
+                },
+                "remove-trailing-separator": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "repeat-element": {
+                    "version": "1.1.3",
+                    "bundled": true
+                },
+                "repeat-string": {
+                    "version": "1.6.1",
+                    "bundled": true
+                },
+                "resolve-url": {
+                    "version": "0.2.1",
+                    "bundled": true
+                },
+                "ret": {
+                    "version": "0.1.15",
+                    "bundled": true
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true
+                },
+                "safe-regex": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "ret": "~0.1.10"
+                    }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "bundled": true
+                },
+                "set-value": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.3",
+                        "split-string": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "short-number": {
+                    "version": "1.0.7",
+                    "bundled": true
+                },
+                "slash": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "snapdragon": {
+                    "version": "0.8.2",
+                    "bundled": true,
+                    "requires": {
+                        "base": "^0.11.1",
+                        "debug": "^2.2.0",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "map-cache": "^0.2.2",
+                        "source-map": "^0.5.6",
+                        "source-map-resolve": "^0.5.0",
+                        "use": "^3.1.0"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "bundled": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "snapdragon-node": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "define-property": "^1.0.0",
+                        "isobject": "^3.0.0",
+                        "snapdragon-util": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^1.0.0",
+                                "is-data-descriptor": "^1.0.0",
+                                "kind-of": "^6.0.2"
+                            }
+                        }
+                    }
+                },
+                "snapdragon-util": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "kind-of": "^3.2.0"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "bundled": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "bundled": true
+                },
+                "source-map-resolve": {
+                    "version": "0.5.2",
+                    "bundled": true,
+                    "requires": {
+                        "atob": "^2.1.1",
+                        "decode-uri-component": "^0.2.0",
+                        "resolve-url": "^0.2.1",
+                        "source-map-url": "^0.4.0",
+                        "urix": "^0.1.0"
+                    }
+                },
+                "source-map-url": {
+                    "version": "0.4.0",
+                    "bundled": true
+                },
+                "split-string": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "extend-shallow": "^3.0.0"
+                    }
+                },
+                "static-extend": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "define-property": "^0.2.5",
+                        "object-copy": "^0.1.0"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "bundled": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "to-object-path": {
+                    "version": "0.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "bundled": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "to-regex": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "regex-not": "^1.0.2",
+                        "safe-regex": "^1.1.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
+                    }
+                },
+                "union-value": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "arr-union": "^3.1.0",
+                        "get-value": "^2.0.6",
+                        "is-extendable": "^0.1.1",
+                        "set-value": "^2.0.1"
+                    }
+                },
+                "unset-value": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "has-value": "^0.3.1",
+                        "isobject": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "has-value": {
+                            "version": "0.3.1",
+                            "bundled": true,
+                            "requires": {
+                                "get-value": "^2.0.3",
+                                "has-values": "^0.1.4",
+                                "isobject": "^2.0.0"
+                            },
+                            "dependencies": {
+                                "isobject": {
+                                    "version": "2.1.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "isarray": "1.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "has-values": {
+                            "version": "0.1.4",
+                            "bundled": true
+                        }
+                    }
+                },
+                "upath": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "urix": {
+                    "version": "0.1.0",
+                    "bundled": true
+                },
+                "use": {
+                    "version": "3.1.1",
+                    "bundled": true
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true
+                }
+            }
+        }
+    }
+}

--- a/components/org.wso2.analytics.apim.widgets/ApiAvailability/package.json
+++ b/components/org.wso2.analytics.apim.widgets/ApiAvailability/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "api-availability",
+    "version": "1.0.0",
+    "private": true,
+    "dependencies": {
+        "@analytics-apim/common-lib": "^1.0.0"
+    },
+    "scripts": {
+        "build": "../node_modules/.bin/webpack -p",
+        "clean": "rimraf dist",
+        "dev": "NODE_ENV=development ../node_modules/.bin/webpack -d --config webpack.config.js --watch --progress"
+    },
+    "devDependencies": {}
+}

--- a/components/org.wso2.analytics.apim.widgets/ApiAvailability/src/ApiAvailability.jsx
+++ b/components/org.wso2.analytics.apim.widgets/ApiAvailability/src/ApiAvailability.jsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -19,21 +19,22 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import { Scrollbars } from 'react-custom-scrollbars';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Paper from '@material-ui/core/Paper';
+import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
-import ApiAvailability from './ApiAvailability';
+import CustomTable from './CustomTable';
 
 /**
  * React Component for Api Availability widget body
  * @param {any} props @inheritDoc
  * @returns {ReactElement} Render the Api Availability widget body
  */
-export default function APIMApiAvailability(props) {
+function ApiAvailability(props) {
     const {
-        themeName, height, availableApiData, legendData, inProgress,
+        themeName, height, availableApiData, inProgress, limit, handleLimitChange, intl,
     } = props;
     const styles = {
         headingWrapper: {
@@ -48,17 +49,14 @@ export default function APIMApiAvailability(props) {
             paddingBottom: '10px',
             marginTop: 0,
         },
-        subheading: {
-            textAlign: 'center',
-            margin: 5,
-            fontSize: 14,
-            color: '#b5b5b5',
-        },
         dataWrapper: {
             height: '75%',
             paddingTop: 35,
             margin: 'auto',
             width: '90%',
+        },
+        tableWrapper: {
+            paddingTop: 10,
         },
         paperWrapper: {
             height: '75%',
@@ -79,8 +77,23 @@ export default function APIMApiAvailability(props) {
             justifyContent: 'center',
             height,
         },
+        formWrapper: {
+            paddingBottom: 20,
+        },
+        formControl: {
+            marginLeft: 10,
+            marginTop: 10,
+            width: '10%',
+        },
     };
-    const availabilityProps = { availableApiData, legendData };
+    const tableData = availableApiData.map((data) => {
+        return {
+            apiname: data.apiname,
+            apiversion: data.apiversion,
+            status: intl.formatMessage({ id: 'availability.' + data.status }),
+            reason: data.reason,
+        };
+    });
 
     return (
         <Scrollbars style={{
@@ -95,8 +108,24 @@ export default function APIMApiAvailability(props) {
             >
                 <div style={styles.headingWrapper}>
                     <h3 style={styles.heading}>
-                        <FormattedMessage id='widget.heading' defaultMessage='API AVAILABILITY SUMMARY' />
+                        <FormattedMessage id='widget.heading' defaultMessage='API AVAILABILITY' />
                     </h3>
+                </div>
+                <div style={styles.formWrapper}>
+                    <form>
+                        <TextField
+                            id='limit-number'
+                            label={<FormattedMessage id='limit' defaultMessage='Limit' />}
+                            value={limit}
+                            onChange={handleLimitChange}
+                            type='number'
+                            style={styles.formControl}
+                            InputLabelProps={{
+                                shrink: true,
+                            }}
+                            margin='normal'
+                        />
+                    </form>
                 </div>
                 <div>
                     { inProgress ? (
@@ -128,21 +157,10 @@ export default function APIMApiAvailability(props) {
                                         </Paper>
                                     </div>
                                 ) : (
-                                    <div>
-                                        <div style={{
-                                            marginTop: '5%',
-                                        }}
-                                        >
-                                            <ApiAvailability {...availabilityProps} />
-                                            <Typography variant='caption' style={{ color: '#9e9e9e' }}>
-                                                <FormattedMessage
-                                                    id='chart.helper.text'
-                                                    defaultMessage={'Please note that API availability is accurately'
-                                                    + ' shown only when alerts are enabled. If alerts are disabled, '
-                                                    + 'the chart will show as 100% availability.'}
-                                                />
-                                            </Typography>
-                                        </div>
+                                    <div style={styles.tableWrapper}>
+                                        <CustomTable
+                                            data={tableData}
+                                        />
                                     </div>
                                 )
                             }
@@ -154,10 +172,14 @@ export default function APIMApiAvailability(props) {
     );
 }
 
-APIMApiAvailability.propTypes = {
+ApiAvailability.propTypes = {
     themeName: PropTypes.string.isRequired,
     height: PropTypes.string.isRequired,
     inProgress: PropTypes.bool.isRequired,
     availableApiData: PropTypes.instanceOf(Object).isRequired,
-    legendData: PropTypes.instanceOf(Object).isRequired,
+    limit: PropTypes.string.isRequired,
+    handleLimitChange: PropTypes.func.isRequired,
+    intl: intlShape.isRequired,
 };
+
+export default injectIntl(ApiAvailability);

--- a/components/org.wso2.analytics.apim.widgets/ApiAvailability/src/ApiAvailabilityWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/ApiAvailability/src/ApiAvailabilityWidget.jsx
@@ -1,0 +1,297 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import React from 'react';
+import {
+    defineMessages, IntlProvider, FormattedMessage, addLocaleData,
+} from 'react-intl';
+import Axios from 'axios';
+import cloneDeep from 'lodash/cloneDeep';
+import { createMuiTheme, MuiThemeProvider } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Paper from '@material-ui/core/Paper';
+import Widget from '@wso2-dashboards/widget';
+import ApiAvailability from './ApiAvailability';
+
+const darkTheme = createMuiTheme({
+    palette: {
+        type: 'dark',
+    },
+    typography: {
+        useNextVariants: true,
+    },
+});
+
+const lightTheme = createMuiTheme({
+    palette: {
+        type: 'light',
+    },
+    typography: {
+        useNextVariants: true,
+    },
+});
+
+const queryParamKey = 'apiAvailability';
+
+/**
+ * Language
+ * @type {string}
+ */
+const language = (navigator.languages && navigator.languages[0]) || navigator.language || navigator.userLanguage;
+
+/**
+ * Language without region code
+ */
+const languageWithoutRegionCode = language.toLowerCase().split(/[_-]+/)[0];
+
+/**
+ * Create React Component for Api Availability
+ * @class ApiAvailabilityWidget
+ * @extends {Widget}
+ */
+class ApiAvailabilityWidget extends Widget {
+    /**
+     * Creates an instance of ApiAvailabilityWidget.
+     * @param {any} props @inheritDoc
+     * @memberof ApiAvailabilityWidget
+     */
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            width: this.props.width,
+            height: this.props.height,
+            availableApiData: [],
+            limit: 5,
+            localeMessages: null,
+            inProgress: true,
+        };
+
+        this.styles = {
+            paper: {
+                padding: '5%',
+                border: '2px solid #4555BB',
+            },
+            paperWrapper: {
+                margin: 'auto',
+                width: '50%',
+                marginTop: '20%',
+            },
+        };
+
+        // This will re-size the widget when the glContainer's width is changed.
+        if (this.props.glContainer !== undefined) {
+            this.props.glContainer.on('resize', () => this.setState({
+                width: this.props.glContainer.width,
+                height: this.props.glContainer.height,
+            }));
+        }
+
+        this.assembleApiAvailableQuery = this.assembleApiAvailableQuery.bind(this);
+        this.handleApiAvailableReceived = this.handleApiAvailableReceived.bind(this);
+        this.handleLimitChange = this.handleLimitChange.bind(this);
+    }
+
+    componentWillMount() {
+        const locale = (languageWithoutRegionCode || language || 'en');
+        this.loadLocale(locale).catch(() => {
+            this.loadLocale().catch(() => {
+                // TODO: Show error message.
+            });
+        });
+    }
+
+    componentDidMount() {
+        const { widgetID } = this.props;
+        this.loadLimit();
+
+        super.getWidgetConfiguration(widgetID)
+            .then((message) => {
+                this.setState({
+                    providerConfig: message.data.configs.providerConfig,
+                }, this.assembleApiAvailableQuery);
+            })
+            .catch((error) => {
+                console.error("Error occurred when loading widget '" + widgetID + "'. " + error);
+                this.setState({
+                    faultyProviderConfig: true,
+                });
+            });
+    }
+
+    componentWillUnmount() {
+        const { id } = this.props;
+        super.getWidgetChannelManager().unsubscribeWidget(id);
+    }
+
+    /**
+     * Load locale file.
+     * @param {string} locale Locale name
+     * @memberof ApiAvailabilityWidget
+     */
+    loadLocale(locale = 'en') {
+        return new Promise((resolve, reject) => {
+            Axios
+                .get(`${window.contextPath}/public/extensions/widgets/ApiAvailability/locales/${locale}.json`)
+                .then((response) => {
+                    // eslint-disable-next-line global-require, import/no-dynamic-require
+                    addLocaleData(require(`react-intl/locale-data/${locale}`));
+                    this.setState({ localeMessages: defineMessages(response.data) });
+                    resolve();
+                })
+                .catch(error => reject(error));
+        });
+    }
+
+    /**
+     * Retrieve the limit from query param
+     * @memberof ApiAvailabilityWidget
+     * */
+    loadLimit() {
+        let { limit } = super.getGlobalState(queryParamKey);
+        if (!limit || limit < 0) {
+            limit = 5;
+        }
+        this.setQueryParam(limit);
+        this.setState({ limit });
+    }
+
+    /**
+     * Formats the siddhi query - apiavailablequery
+     * @memberof ApiAvailabilityWidget
+     * */
+    assembleApiAvailableQuery() {
+        const { providerConfig, limit } = this.state;
+        const { id, widgetID: widgetName } = this.props;
+
+        if (limit > 0) {
+            const dataProviderConfigs = cloneDeep(providerConfig);
+            dataProviderConfigs.configs.config.queryData.queryName = 'apiavailablequery';
+            dataProviderConfigs.configs.config.queryData.queryValues = {
+                '{{limit}}': limit,
+            };
+            super.getWidgetChannelManager()
+                .subscribeWidget(id, widgetName, this.handleApiAvailableReceived, dataProviderConfigs);
+        } else {
+            this.setState({ inProgress: false, availableApiData: [] });
+        }
+    }
+
+    /**
+     * Formats data received from assembleApiAvailableQuery
+     * @param {object} message - data retrieved
+     * @memberof ApiAvailabilityWidget
+     * */
+    handleApiAvailableReceived(message) {
+        const { data } = message;
+
+        if (data && data.length > 0) {
+            const availableApiData = data.map((dataUnit) => {
+                return {
+                    apiname: dataUnit[0] + ' (' + dataUnit[2] + ')',
+                    apiversion: dataUnit[1],
+                    status: dataUnit[3] === 'Available' ? 'available' : 'limited',
+                    reason: dataUnit[3],
+                };
+            });
+            this.setState({ availableApiData, inProgress: false });
+        } else {
+            this.setState({ inProgress: false, availableApiData: [] });
+        }
+    }
+
+    /**
+     * Updates query param values
+     * @param {number} limit - data limitation value
+     * @memberof ApiAvailabilityWidget
+     * */
+    setQueryParam(limit) {
+        super.setGlobalState(queryParamKey, { limit });
+    }
+
+    /**
+     * Handle Limit select Change
+     * @param {Event} event - listened event
+     * @memberof ApiAvailabilityWidget
+     * */
+    handleLimitChange(event) {
+        const limit = (event.target.value).replace('-', '').split('.')[0];
+
+        this.setQueryParam(parseInt(limit, 10));
+        if (limit) {
+            this.setState({ inProgress: true, limit }, this.assembleApiAvailableQuery);
+        } else {
+            this.setState({ limit });
+        }
+    }
+
+    /**
+     * @inheritDoc
+     * @returns {ReactElement} Render the Api Availability widget
+     * @memberof ApiAvailabilityWidget
+     */
+    render() {
+        const {
+            localeMessages, faultyProviderConfig, height, availableApiData, inProgress, limit,
+        } = this.state;
+        const {
+            paper, paperWrapper,
+        } = this.styles;
+        const { muiTheme } = this.props;
+        const themeName = muiTheme.name;
+        const apiAvailabilityProps = {
+            themeName, height, availableApiData, inProgress, limit,
+        };
+
+        return (
+            <IntlProvider locale={language} messages={localeMessages}>
+                <MuiThemeProvider theme={themeName === 'dark' ? darkTheme : lightTheme}>
+                    {
+                        faultyProviderConfig ? (
+                            <div style={paperWrapper}>
+                                <Paper elevation={1} style={paper}>
+                                    <Typography variant='h5' component='h3'>
+                                        <FormattedMessage
+                                            id='config.error.heading'
+                                            defaultMessage='Configuration Error !'
+                                        />
+                                    </Typography>
+                                    <Typography component='p'>
+                                        <FormattedMessage
+                                            id='config.error.body'
+                                            defaultMessage={'Cannot fetch provider configuration for '
+                                            + ' Api Availability widget'}
+                                        />
+                                    </Typography>
+                                </Paper>
+                            </div>
+                        ) : (
+                            <ApiAvailability
+                                {...apiAvailabilityProps}
+                                handleLimitChange={this.handleLimitChange}
+                            />
+                        )
+                    }
+                </MuiThemeProvider>
+            </IntlProvider>
+        );
+    }
+}
+
+global.dashboard.registerWidget('ApiAvailability', ApiAvailabilityWidget);

--- a/components/org.wso2.analytics.apim.widgets/ApiAvailability/src/CustomTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/ApiAvailability/src/CustomTable.jsx
@@ -1,0 +1,340 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CustomTableToolbar } from '@analytics-apim/common-lib';
+import { FormattedMessage } from 'react-intl';
+import MenuItem from '@material-ui/core/MenuItem';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TablePagination from '@material-ui/core/TablePagination';
+import TableRow from '@material-ui/core/TableRow';
+import Paper from '@material-ui/core/Paper';
+import Tooltip from '@material-ui/core/Tooltip';
+import CheckCircleRoundedIcon from '@material-ui/icons/CheckCircleRounded';
+import WarningRoundedIcon from '@material-ui/icons/WarningRounded';
+import { withStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+import CustomTableHead from './CustomTableHead';
+/**
+ * Compare two values and return the result
+ * @param {object} a - data field
+ * @param {object} b - data field
+ * @param {string} orderBy - column to sort table
+ * @return {number}
+ * */
+function desc(a, b, orderBy) {
+    let tempa = a[orderBy];
+    let tempb = b[orderBy];
+
+    if (typeof (tempa) === 'string') {
+        tempa = tempa.toLowerCase();
+        tempb = tempb.toLowerCase();
+    }
+
+    if (tempb < tempa) {
+        return -1;
+    }
+    if (tempb > tempa) {
+        return 1;
+    }
+    return 0;
+}
+
+/**
+ * Stabilize the data set and sort the data fields
+ * @param {object} array - data set
+ * @param {object} cmp - method to sort
+ * @return {object}
+ * */
+function stableSort(array, cmp) {
+    const stabilizedThis = array.map((el, index) => [el, index]);
+    stabilizedThis.sort((a, b) => {
+        const order = cmp(a[0], b[0]);
+        if (order !== 0) return order;
+        return a[1] - b[1];
+    });
+    return stabilizedThis.map(el => el[0]);
+}
+
+/**
+ * Set the value received from desc() according to 'order'
+ * @param {string} order - desc or asc
+ * @param {string} orderBy - column to sort table
+ * @return {object}
+ * */
+function getSorting(order, orderBy) {
+    return order === 'desc' ? (a, b) => desc(a, b, orderBy) : (a, b) => -desc(a, b, orderBy);
+}
+
+const styles = theme => ({
+    root: {
+        width: '100%',
+        backgroundColor: theme.palette.type === 'light' ? '#fff' : '#162638',
+    },
+    table: {
+        minWidth: 200,
+    },
+    tableWrapper: {
+        overflowX: 'auto',
+    },
+    loadingIcon: {
+        margin: 'auto',
+        display: 'block',
+    },
+    paginationRoot: {
+        color: theme.palette.text.secondary,
+        fontSize: theme.typography.pxToRem(12),
+        '&:last-child': {
+            padding: 0,
+        },
+    },
+    paginationToolbar: {
+        height: 56,
+        minHeight: 56,
+        padding: '0 5%',
+    },
+    paginationCaption: {
+        flexShrink: 0,
+    },
+    paginationSelectRoot: {
+        marginRight: '10px',
+    },
+    paginationSelect: {
+        paddingLeft: 8,
+        paddingRight: 16,
+    },
+    paginationSelectIcon: {
+        top: 1,
+    },
+    paginationInput: {
+        color: 'inherit',
+        fontSize: 'inherit',
+        flexShrink: 0,
+    },
+    paginationMenuItem: {
+        backgroundColor: theme.palette.type === 'light' ? '#fff' : '#162638',
+    },
+    paginationActions: {
+        marginLeft: 0,
+    },
+    statusCell: {
+        display: 'flex',
+    },
+    statusContainer: {
+        paddingTop: 5,
+        paddingLeft: 10,
+    },
+});
+
+/**
+ * Create React Component for Top Rated APIs Table
+ */
+class CustomTable extends React.Component {
+    /**
+     * Creates an instance of CustomTable.
+     * @param {any} props @inheritDoc
+     * @memberof CustomTable
+     */
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            tableData: [],
+            page: 0,
+            rowsPerPage: 5,
+            orderBy: 'apiname',
+            order: 'asc',
+            expanded: false,
+            filterColumn: 'apiname',
+            query: '',
+        };
+    }
+
+    handleRequestSort = (event, property) => {
+        const { order, orderBy } = this.state;
+        let orderNew = 'desc';
+        if (orderBy === property && order === 'desc') {
+            orderNew = 'asc';
+        }
+        this.setState({ order: orderNew, orderBy: property });
+    };
+
+    handleChangePage = (event, page) => {
+        this.setState({ page });
+    };
+
+    handleChangeRowsPerPage = (event) => {
+        this.setState({ rowsPerPage: event.target.value });
+    };
+
+    handleExpandClick = () => {
+        this.setState(state => ({ expanded: !state.expanded }));
+    };
+
+    handleColumnSelect = (event) => {
+        this.setState({ filterColumn: event.target.value });
+    };
+
+    handleQueryChange = (event) => {
+        this.setState({ query: event.target.value });
+    };
+
+    /**
+     * Render the Custom Table
+     * @return {ReactElement} customTable
+     */
+    render() {
+        const {
+            data, classes,
+        } = this.props;
+        const {
+            query, expanded, filterColumn, order, orderBy, rowsPerPage, page,
+        } = this.state;
+
+        this.state.tableData = query
+            ? data.filter(x => x[filterColumn].toString().toLowerCase().includes(query.toLowerCase()))
+            : data;
+        const { tableData } = this.state;
+        const emptyRows = rowsPerPage - Math.min(rowsPerPage, tableData.length - page * rowsPerPage);
+
+        const menuItems = [
+            <MenuItem value='apiname'>
+                <FormattedMessage id='table.heading.apiname' defaultMessage='API NAME' />
+            </MenuItem>,
+            <MenuItem value='apiversion'>
+                <FormattedMessage id='table.heading.apiversion' defaultMessage='VERSION' />
+            </MenuItem>,
+            <MenuItem value='status'>
+                <FormattedMessage id='table.heading.status' defaultMessage='STATUS' />
+            </MenuItem>,
+        ];
+        return (
+            <Paper className={classes.root}>
+                <CustomTableToolbar
+                    expanded={expanded}
+                    filterColumn={filterColumn}
+                    query={query}
+                    handleExpandClick={this.handleExpandClick}
+                    handleColumnSelect={this.handleColumnSelect}
+                    handleQueryChange={this.handleQueryChange}
+                    menuItems={menuItems}
+                />
+                <div>
+                    <div className={classes.tableWrapper}>
+                        <Table className={classes.table} aria-labelledby='tableTitle'>
+                            <colgroup>
+                                <col style={{ width: '35%' }} />
+                                <col style={{ width: '30%' }} />
+                                <col style={{ width: '35%' }} />
+                            </colgroup>
+                            <CustomTableHead
+                                order={order}
+                                orderBy={orderBy}
+                                onRequestSort={this.handleRequestSort}
+                            />
+                            <TableBody>
+                                {stableSort(tableData, getSorting(order, orderBy))
+                                    .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                                    .map((n) => {
+                                        return (
+                                            <TableRow
+                                                hover
+                                                tabIndex={-1}
+                                            >
+                                                <TableCell component='th' scope='row'>
+                                                    {n.apiname}
+                                                </TableCell>
+                                                <TableCell numeric>
+                                                    {n.apiversion}
+                                                </TableCell>
+                                                <TableCell>
+                                                    <Tooltip
+                                                        title={n.reason}
+                                                        placement='bottom-start'
+                                                        disableHoverListener={n.reason === 'Available'}
+                                                    >
+                                                        <div className={classes.statusCell}>
+                                                            <div>
+                                                                {n.reason === 'Available' ? (
+                                                                    <CheckCircleRoundedIcon
+                                                                        style={{ color: '#669933' }}
+                                                                    />
+                                                                ) : (
+                                                                    <WarningRoundedIcon style={{ color: '#ffcc66' }} />
+                                                                )
+                                                                }
+                                                            </div>
+                                                            <div className={classes.statusContainer}>
+                                                                {n.status}
+                                                            </div>
+                                                        </div>
+                                                    </Tooltip>
+                                                </TableCell>
+                                            </TableRow>
+                                        );
+                                    })}
+                                {emptyRows > 0 && (
+                                    <TableRow style={{ height: 49 * emptyRows }}>
+                                        <TableCell colSpan={6} />
+                                    </TableRow>
+                                )}
+                            </TableBody>
+                        </Table>
+                    </div>
+                </div>
+                <TablePagination
+                    rowsPerPageOptions={[5, 10, 20, 25, 50, 100]}
+                    component='div'
+                    count={tableData.length}
+                    rowsPerPage={rowsPerPage}
+                    page={page}
+                    backIconButtonProps={{
+                        'aria-label': 'Previous Page',
+                    }}
+                    nextIconButtonProps={{
+                        'aria-label': 'Next Page',
+                    }}
+                    onChangePage={this.handleChangePage}
+                    onChangeRowsPerPage={this.handleChangeRowsPerPage}
+                    classes={{
+                        root: classes.paginationRoot,
+                        toolbar: classes.paginationToolbar,
+                        caption: classes.paginationCaption,
+                        selectRoot: classes.paginationSelectRoot,
+                        select: classes.paginationSelect,
+                        selectIcon: classes.paginationSelectIcon,
+                        input: classes.paginationInput,
+                        menuItem: classes.paginationMenuItem,
+                        actions: classes.paginationActions,
+                    }}
+                />
+            </Paper>
+        );
+    }
+}
+
+CustomTable.propTypes = {
+    classes: PropTypes.instanceOf(Object).isRequired,
+    data: PropTypes.instanceOf(Object).isRequired,
+};
+
+export default withStyles(styles)(CustomTable);

--- a/components/org.wso2.analytics.apim.widgets/ApiAvailability/src/CustomTableHead.jsx
+++ b/components/org.wso2.analytics.apim.widgets/ApiAvailability/src/CustomTableHead.jsx
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import TableHead from '@material-ui/core/TableHead';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+import Tooltip from '@material-ui/core/Tooltip';
+import TableSortLabel from '@material-ui/core/TableSortLabel';
+
+const rows = [
+    {
+        id: 'apiname', numeric: false, disablePadding: false, label: 'table.heading.apiname',
+    },
+    {
+        id: 'apiversion', numeric: true, disablePadding: false, label: 'table.heading.apiversion',
+    },
+    {
+        id: 'status', numeric: false, disablePadding: false, label: 'table.heading.status',
+    },
+];
+
+/**
+ * Create React Component for Custom Table Head
+ */
+export default class CustomTableHead extends React.Component {
+    createSortHandler = property => (event) => {
+        const { onRequestSort } = this.props;
+        onRequestSort(event, property);
+    };
+
+    /**
+     * Render the Custom Table Head
+     * @return {ReactElement} customTableHead
+     */
+    render() {
+        const { order, orderBy } = this.props;
+
+        return (
+            <TableHead>
+                <TableRow>
+                    {rows.map((row) => {
+                        return (
+                            <TableCell
+                                key={row.id}
+                                numeric={row.numeric}
+                                padding={row.disablePadding ? 'none' : 'default'}
+                                sortDirection={orderBy === row.id ? order : false}
+                            >
+                                <Tooltip
+                                    title={<FormattedMessage id='sort.label.title' defaultMessage='Sort' />}
+                                    placement={row.numeric ? 'bottom-end' : 'bottom-start'}
+                                    enterDelay={300}
+                                >
+                                    <TableSortLabel
+                                        active={orderBy === row.id}
+                                        direction={order}
+                                        onClick={this.createSortHandler(row.id)}
+                                    >
+                                        <FormattedMessage
+                                            id={row.label}
+                                            defaultMessage={row.label.split('table.heading.')[1].toUpperCase()}
+                                        />
+                                    </TableSortLabel>
+                                </Tooltip>
+                            </TableCell>
+                        );
+                    }, this)}
+                </TableRow>
+            </TableHead>
+        );
+    }
+}
+
+CustomTableHead.propTypes = {
+    onRequestSort: PropTypes.func.isRequired,
+    order: PropTypes.string.isRequired,
+    orderBy: PropTypes.string.isRequired,
+};

--- a/components/org.wso2.analytics.apim.widgets/ApiAvailability/src/resources/locales/en.json
+++ b/components/org.wso2.analytics.apim.widgets/ApiAvailability/src/resources/locales/en.json
@@ -1,0 +1,14 @@
+{
+  "availability.available" : "Available",
+  "availability.limited" : "Limited",
+  "config.error.body": "Cannot fetch provider configuration for Api Availability widget",
+  "config.error.heading": "Configuration Error !",
+  "limit": "Limit",
+  "nodata.error.body": "No data available for the selected options",
+  "nodata.error.heading": "No Data Available !",
+  "sort.label.title": "Sort",
+  "table.heading.apiname": "API NAME",
+  "table.heading.apiversion": "VERSION",
+  "table.heading.status": "STATUS",
+  "widget.heading": "API AVAILABILITY"
+}

--- a/components/org.wso2.analytics.apim.widgets/ApiAvailability/src/resources/widgetConf.json
+++ b/components/org.wso2.analytics.apim.widgets/ApiAvailability/src/resources/widgetConf.json
@@ -1,6 +1,6 @@
 {
-  "name": "APIM Api Availability",
-  "id": "APIMApiAvailability",
+  "name": "Api Availability",
+  "id": "ApiAvailability",
   "thumbnailURL": "",
   "configs": {
     "pubsub": {
@@ -10,9 +10,9 @@
       "configs": {
         "type": "SiddhiStoreDataProvider",
         "config": {
-          "siddhiApp": "@App:name('APIMApiAvailabilitySiddhi') @store(type='rdbms' , datasource='APIM_ANALYTICS_DB') define table ApimApiAvailabilityInfo(apiName string,apiVersion string,apiCreator string,tenantDomain string,status string);",
+          "siddhiApp": "@App:name('ApiAvailabilitySiddhi') @store(type='rdbms' , datasource='APIM_ANALYTICS_DB') define table ApimApiAvailabilityInfo(apiName string,apiVersion string,apiCreator string,tenantDomain string,status string);",
           "queryData": {
-            "apiavailablequery": "from ApimApiAvailabilityInfo on tenantDomain=='{{tenantDomain}}' select status,count(apiName) as count group by status;"
+            "apiavailablequery": "from ApimApiAvailabilityInfo on tenantDomain=='{{tenantDomain}}' select apiName,apiVersion,apiCreator,status order by apiName asc limit {{limit}};"
           },
           "publishingInterval": 60
         }
@@ -37,7 +37,7 @@
         "type": {
           "name": "TEXT"
         },
-        "defaultValue": "API Availability Summary"
+        "defaultValue": "API Availability"
       }
     ]
   }

--- a/components/org.wso2.analytics.apim.widgets/ApiAvailability/webpack.config.js
+++ b/components/org.wso2.analytics.apim.widgets/ApiAvailability/webpack.config.js
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+const path = require('path');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+
+module.exports = {
+    context: path.resolve(__dirname, './src'),
+    entry: {
+        index: './ApiAvailabilityWidget.jsx',
+    },
+    output: {
+        path: path.resolve(__dirname, './dist/ApiAvailability'),
+        filename: 'ApiAvailability.js',
+    },
+    module: {
+        rules: [
+            {
+                test: /\.html$/,
+                use: [{ loader: 'html-loader' }],
+            },
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'babel-loader',
+                        query: {
+                            presets: ['@babel/preset-env', '@babel/preset-react'],
+                        },
+                    },
+                ],
+            },
+            {
+                test: /\.(png|jpg|svg|cur|gif|eot|ttf|woff|woff2)$/,
+                use: ['url-loader'],
+            },
+            {
+                test: /\.jsx?$/,
+                exclude: /(node_modules)/,
+                loader: 'babel-loader',
+                query: {
+                    presets: ['@babel/preset-env', '@babel/preset-react'],
+                    plugins: ['@babel/plugin-proposal-class-properties'],
+                },
+            },
+            {
+                test: /\.css$/,
+                use: ['style-loader', 'css-loader'],
+            },
+            {
+                test: /\.scss$/,
+                use: [{ loader: 'style-loader' }, { loader: 'css-loader' }, { loader: 'sass-loader' }],
+            },
+
+        ],
+    },
+    plugins: [
+        new CopyWebpackPlugin([
+            { from: path.resolve(__dirname, './src/resources/') },
+        ]),
+    ],
+    resolve: {
+        extensions: ['.js', '.json', '.jsx', '.scss'],
+    },
+    externals: { react: 'React', 'react-dom': 'ReactDOM' },
+};

--- a/components/org.wso2.analytics.apim.widgets/assembly.xml
+++ b/components/org.wso2.analytics.apim.widgets/assembly.xml
@@ -287,5 +287,9 @@
             <directory>ThrottleSummary/dist</directory>
             <outputDirectory></outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>ApiAvailability/dist</directory>
+            <outputDirectory></outputDirectory>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/components/org.wso2.analytics.apim.widgets/lerna.json
+++ b/components/org.wso2.analytics.apim.widgets/lerna.json
@@ -65,7 +65,8 @@
     "APILatencyOverTime",
     "APIMApiTrafficByVersion",
     "PerformanceSummary",
-    "ThrottleSummary"
+    "ThrottleSummary",
+    "ApiAvailability"
   ],
   "version": "1.0.0"
 }

--- a/features/org.wso2.analytics.apim.feature/src/main/resources/dashboard/monitoring.json
+++ b/features/org.wso2.analytics.apim.feature/src/main/resources/dashboard/monitoring.json
@@ -29,7 +29,7 @@
                       "type": "stack",
                       "isClosable": true,
                       "title": "",
-                      "width": 22.97320938135093,
+                      "width": 30.930789937113282,
                       "content": [
                         {
                           "title": "[APIM Api Usage Summary]",
@@ -64,7 +64,7 @@
                       "isClosable": true,
                       "title": "",
                       "height": 28.125,
-                      "width": 25.34162789320254,
+                      "width": 37.95094618961678,
                       "content": [
                         {
                           "title": "[APIM Faults Summary]",
@@ -98,7 +98,7 @@
                       "type": "stack",
                       "isClosable": true,
                       "title": "",
-                      "width": 26.463797260865643,
+                      "width": 31.11826387326994,
                       "content": [
                         {
                           "title": "[APIM Throttled Api Summary]",
@@ -669,17 +669,136 @@
               "title": "",
               "content": [
                 {
+                  "type": "row",
+                  "isClosable": true,
+                  "title": "",
+                  "height": 29.54361757839729,
+                  "content": [
+                    {
+                      "type": "stack",
+                      "isClosable": true,
+                      "title": "",
+                      "width": 38.7037037037037,
+                      "height": 100.00000000000003,
+                      "content": [
+                        {
+                          "title": "[APIM Api Availability]",
+                          "type": "component",
+                          "component": "APIMApiAvailability",
+                          "props": {
+                            "id": "5f6ccc95-6fbf-407d-8770-e842b18deb72",
+                            "configs": {
+                              "pubsub": {
+                                "types": [
+                                  "subscriber"
+                                ]
+                              },
+                              "isGenerated": false,
+                              "options": {
+                                "header": true,
+                                "headerTitle": "API Availability Summary"
+                              }
+                            },
+                            "widgetID": "APIMApiAvailability"
+                          },
+                          "isClosable": false,
+                          "header": {
+                            "show": true
+                          },
+                          "componentName": "lm-react-component"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "stack",
+                      "isClosable": true,
+                      "title": "",
+                      "width": 61.29629629629629,
+                      "content": [
+                        {
+                          "title": "[Api Availability]",
+                          "type": "component",
+                          "component": "ApiAvailability",
+                          "props": {
+                            "id": "00c41ed9-eee4-4fe7-9b02-c9897cfdca5e",
+                            "configs": {
+                              "pubsub": {
+                                "types": [
+                                  "subscriber"
+                                ],
+                                "publishers": [
+                                  "006edbd8-8703-4a64-8bb4-a476b4a127a8"
+                                ]
+                              },
+                              "isGenerated": false,
+                              "options": {
+                                "header": true,
+                                "headerTitle": "API Availability"
+                              }
+                            },
+                            "widgetID": "ApiAvailability"
+                          },
+                          "isClosable": false,
+                          "header": {
+                            "show": true
+                          },
+                          "componentName": "lm-react-component"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
                   "type": "stack",
                   "isClosable": true,
                   "title": "",
-                  "height": 7.212089763832891,
+                  "height": 29.54415564471445,
+                  "content": [
+                    {
+                      "title": "[APIM Alert Summary By APIs]",
+                      "type": "component",
+                      "component": "APIMAlertSummaryByAPIs",
+                      "props": {
+                        "id": "69e6e1ee-67bf-4186-a276-536724d4e517",
+                        "configs": {
+                          "pubsub": {
+                            "types": [
+                              "publisher"
+                            ],
+                            "publisherWidgetOutputs": [
+                              "selectedApi"
+                            ],
+                            "publishers": []
+                          },
+                          "isGenerated": false,
+                          "options": {
+                            "header": true,
+                            "headerTitle": "Top API by Alerts",
+                            "drillDown": true
+                          }
+                        },
+                        "widgetID": "APIMAlertSummaryByAPIs"
+                      },
+                      "isClosable": false,
+                      "header": {
+                        "show": true
+                      },
+                      "componentName": "lm-react-component"
+                    }
+                  ]
+                },
+                {
+                  "type": "stack",
+                  "isClosable": true,
+                  "title": "",
+                  "height": 4.697155772317826,
                   "content": [
                     {
                       "title": "[Date Time Range]",
                       "type": "component",
                       "component": "DateRangePicker",
                       "props": {
-                        "id": "c1651b66-a7e1-4875-baa9-0b8e628a233c",
+                        "id": "32761c20-92be-4c5f-b50b-142a36b884b0",
                         "configs": {
                           "pubsub": {
                             "types": [
@@ -714,59 +833,22 @@
                   "type": "stack",
                   "isClosable": true,
                   "title": "",
-                  "height": 48.8516626019266,
-                  "content": [
-                    {
-                      "title": "[APIM Alert Summary By APIs]",
-                      "type": "component",
-                      "component": "APIMAlertSummaryByAPIs",
-                      "props": {
-                        "id": "d3efa2d1-5788-4c4b-8783-0f43611b1039",
-                        "configs": {
-                          "pubsub": {
-                            "types": [
-                              "subscriber"
-                            ],
-                            "publishers": [
-                              "c1651b66-a7e1-4875-baa9-0b8e628a233c"
-                            ]
-                          },
-                          "isGenerated": false,
-                          "options": {
-                            "header": true,
-                            "headerTitle": "Top Throttled Out APIs",
-                            "drillDown": "api-faults"
-                          }
-                        },
-                        "widgetID": "APIMAlertSummaryByAPIs"
-                      },
-                      "isClosable": false,
-                      "header": {
-                        "show": true
-                      },
-                      "componentName": "lm-react-component"
-                    }
-                  ]
-                },
-                {
-                  "type": "stack",
-                  "isClosable": true,
-                  "title": "",
-                  "height": 43.936247634240495,
+                  "height": 36.21507100457043,
                   "content": [
                     {
                       "title": "[APIM Alert Summary]",
                       "type": "component",
                       "component": "APIMAlertSummary",
                       "props": {
-                        "id": "2df628ec-7984-44a8-8444-d537d5ac0e37",
+                        "id": "70009f61-fcb7-4847-8cc4-a9e518c5f1fb",
                         "configs": {
                           "pubsub": {
                             "types": [
                               "subscriber"
                             ],
                             "publishers": [
-                              "c1651b66-a7e1-4875-baa9-0b8e628a233c"
+                              "54fe9519-effe-42e7-89f3-33d499892840",
+                              "32761c20-92be-4c5f-b50b-142a36b884b0"
                             ]
                           },
                           "isGenerated": false,
@@ -788,7 +870,7 @@
               ]
             }
           ],
-          "height": 1333
+          "height": 2144
         }
       ]
     },


### PR DESCRIPTION
## Purpose
- Add API availability widget(fixes https://github.com/wso2/analytics-apim/issues/1167)
- Add API filter to alerts summary widget(fixes https://github.com/wso2/analytics-apim/issues/1168)
- Add time base filtering to alerts summary widget

_API availability widget_
<img width="1634" alt="api_availability" src="https://user-images.githubusercontent.com/20040505/84374599-d82a1900-abfb-11ea-89df-72245bc4cfb8.png">

_Alert page in monitoring dashboard_
<img width="1674" alt="1" src="https://user-images.githubusercontent.com/20040505/84374393-8e413300-abfb-11ea-972a-12fed903144f.png">
<img width="1671" alt="2" src="https://user-images.githubusercontent.com/20040505/84374385-8aadac00-abfb-11ea-9936-a499c617ee9a.png">
<img width="1665" alt="3" src="https://user-images.githubusercontent.com/20040505/84374362-83869e00-abfb-11ea-8a15-6b74d651ac98.png">



