### PR TITLE
Fix analytics dashboard drill downs to use query params instead of hash

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/APIMApiCreatedAnalytics/src/APIMApiCreatedAnalyticsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiCreatedAnalytics/src/APIMApiCreatedAnalyticsWidget.jsx
@@ -313,10 +313,15 @@ class APIMApiCreatedAnalyticsWidget extends Widget {
                 const provider = (apiname.split('(')[1]).split(')')[0].trim();
                 const locationParts = window.location.pathname.split('/');
                 const dashboard = locationParts[locationParts.length - 2];
-
+                const queryParams = {
+                    dmSelc: {
+                        dm: 'api',
+                        op: [{ name: api, version: apiversion, provider }],
+                    },
+                };
                 window.location.href = window.contextPath
-                    + '/dashboards/' + dashboard + '/' + drillDown + '#{"dmSelc":{"dm":"api","op":[{"name":"' + api
-                    + '","version":"' + apiversion + '","provider":"' + provider + '"}]}}';
+                    + '/dashboards/' + dashboard + '/' + drillDown + '?widgetStates='
+                    + encodeURI(JSON.stringify(queryParams));
             }
         }
     }

--- a/components/org.wso2.analytics.apim.widgets/APIMApiCreatedAnalytics/src/CustomTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiCreatedAnalytics/src/CustomTable.jsx
@@ -22,7 +22,6 @@ import Moment from 'moment';
 import PropTypes from 'prop-types';
 import { CustomTableToolbar } from '@analytics-apim/common-lib';
 import { FormattedMessage } from 'react-intl';
-import Link from '@material-ui/core/Link';
 import MenuItem from '@material-ui/core/MenuItem';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -144,6 +143,9 @@ const styles = theme => ({
     title: {
         paddingLeft: 20,
         paddingTop: 15,
+    },
+    tableRow: {
+        cursor: 'pointer',
     },
 });
 
@@ -272,11 +274,11 @@ class CustomTable extends React.Component {
                                         <TableRow
                                             hover
                                             tabIndex={-1}
+                                            className={classes.tableRow}
+                                            onClick={() => onClickTableRow(n)}
                                         >
                                             <TableCell component='th' scope='row'>
-                                                <Link href='#' onClick={() => onClickTableRow(n)} color='inherit'>
-                                                    {n.apiname}
-                                                </Link>
+                                                {n.apiname}
                                             </TableCell>
                                             <TableCell component='th' scope='row'>
                                                 {n.apiversion}

--- a/components/org.wso2.analytics.apim.widgets/APIMApiRatings/src/APIMApiRatings.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiRatings/src/APIMApiRatings.jsx
@@ -79,6 +79,9 @@ function APIMApiRatings(props) {
             id: 'apiname', numeric: false, disablePadding: false, label: 'table.heading.apiname',
         },
         {
+            id: 'apiversion', numeric: true, disablePadding: false, label: 'table.heading.apiversion',
+        },
+        {
             id: 'ratings', numeric: true, disablePadding: false, label: 'table.heading.ratings',
         },
     ];

--- a/components/org.wso2.analytics.apim.widgets/APIMApiRatings/src/APIMApiRatingsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiRatings/src/APIMApiRatingsWidget.jsx
@@ -268,10 +268,15 @@ class APIMApiRatingsWidget extends Widget {
                 const provider = (apiname.split('(')[1]).split(')')[0].trim();
                 const locationParts = window.location.pathname.split('/');
                 const dashboard = locationParts[locationParts.length - 2];
-
+                const queryParams = {
+                    dmSelc: {
+                        dm: 'api',
+                        op: [{ name: api, version: apiversion, provider }],
+                    },
+                };
                 window.location.href = window.contextPath
-                    + '/dashboards/' + dashboard + '/' + drillDown + '#{"dmSelc":{"dm":"api","op":[{"name":"'
-                    + api + '","version":"' + apiversion + '","provider":"' + provider + '"}]}}';
+                    + '/dashboards/' + dashboard + '/' + drillDown + '?widgetStates='
+                    + encodeURI(JSON.stringify(queryParams));
             }
         }
     }

--- a/components/org.wso2.analytics.apim.widgets/APIMApiRatings/src/CustomTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiRatings/src/CustomTable.jsx
@@ -21,7 +21,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CustomTableToolbar } from '@analytics-apim/common-lib';
 import { FormattedMessage } from 'react-intl';
-import Link from '@material-ui/core/Link';
 import MenuItem from '@material-ui/core/MenuItem';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Table from '@material-ui/core/Table';
@@ -144,6 +143,9 @@ const styles = theme => ({
         alignItems: 'center',
         justifyContent: 'center',
         color: '#888888',
+    },
+    tableRow: {
+        cursor: 'pointer',
     },
 });
 
@@ -275,15 +277,11 @@ class CustomTable extends React.Component {
                                                         <TableRow
                                                             hover
                                                             tabIndex={-1}
+                                                            className={classes.tableRow}
+                                                            onClick={() => onClickTableRow(n)}
                                                         >
                                                             <TableCell component='th' scope='row'>
-                                                                <Link
-                                                                    href='#'
-                                                                    onClick={() => onClickTableRow(n)}
-                                                                    color='inherit'
-                                                                >
-                                                                    {n.apiname}
-                                                                </Link>
+                                                                {n.apiname}
                                                             </TableCell>
                                                             <TableCell numeric>
                                                                 {n.apiversion}

--- a/components/org.wso2.analytics.apim.widgets/APIMApiUsage/src/APIMApiUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiUsage/src/APIMApiUsageWidget.jsx
@@ -51,7 +51,7 @@ const lightTheme = createMuiTheme({
  * Query string parameter
  * @type {string}
  */
-const queryParamKey = 'apiUsers';
+const queryParamKey = 'apiUsage';
 
 /**
  * Language
@@ -321,12 +321,24 @@ class APIMApiUsageWidget extends Widget {
                 const provider = (api.split('(')[1]).split(')')[0].trim();
                 const locationParts = window.location.pathname.split('/');
                 const dashboard = locationParts[locationParts.length - 2];
-
+                const queryParams = {
+                    dtrp: {
+                        tr,
+                        sd,
+                        ed,
+                        g,
+                    },
+                    dmSelc: {
+                        dm: 'api',
+                        op: [{ name: apiname, version: apiversion, provider }],
+                    },
+                    apiUsageTime: {
+                        selectedApp: application,
+                    },
+                };
                 window.location.href = window.contextPath
-                    + '/dashboards/' + dashboard + '/' + drillDown + '#{"dtrp":{"tr":"' + tr + '","sd":"' + sd
-                    + '","ed":"' + ed + '","g":"' + g + '"},"dmSelc":{"dm":"api","op":[{"name":"'
-                    + apiname + '","version":"' + apiversion + '","provider":"' + provider + '"}]},'
-                    + '"apiUsageTime":{"selectedApp":"' + application + '"}}';
+                    + '/dashboards/' + dashboard + '/' + drillDown + '?widgetStates='
+                    + encodeURI(JSON.stringify(queryParams));
             }
         }
     }

--- a/components/org.wso2.analytics.apim.widgets/APIMApiUsage/src/CustomTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiUsage/src/CustomTable.jsx
@@ -21,7 +21,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CustomTableToolbar } from '@analytics-apim/common-lib';
 import { FormattedMessage } from 'react-intl';
-import Link from '@material-ui/core/Link';
 import MenuItem from '@material-ui/core/MenuItem';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -132,6 +131,9 @@ const styles = theme => ({
     },
     paginationActions: {
         marginLeft: 0,
+    },
+    tableRow: {
+        cursor: 'pointer',
     },
 });
 
@@ -259,11 +261,11 @@ class CustomTable extends React.Component {
                                         <TableRow
                                             hover
                                             tabIndex={-1}
+                                            onClick={() => onClickTableRow(n)}
+                                            className={classes.tableRow}
                                         >
                                             <TableCell component='th' scope='row'>
-                                                <Link href='#' onClick={() => onClickTableRow(n)} color='inherit'>
-                                                    {n.api}
-                                                </Link>
+                                                {n.api}
                                             </TableCell>
                                             <TableCell component='th' scope='row' numeric>
                                                 {n.apiversion}

--- a/components/org.wso2.analytics.apim.widgets/APIMOverallApiUsage/src/APIMOverallApiUsageWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMOverallApiUsage/src/APIMOverallApiUsageWidget.jsx
@@ -503,11 +503,21 @@ class APIMOverallApiUsageWidget extends Widget {
                 const provider = (apiname.split('(')[1]).split(')')[0].trim();
                 const locationParts = window.location.pathname.split('/');
                 const dashboard = locationParts[locationParts.length - 2];
-
+                const queryParams = {
+                    dtrp: {
+                        tr,
+                        sd,
+                        ed,
+                        g,
+                    },
+                    dmSelc: {
+                        dm: 'api',
+                        op: [{ name: api, version: apiversion, provider }],
+                    },
+                };
                 window.location.href = window.contextPath
-                    + '/dashboards/' + dashboard + '/' + drillDown + '#{"dtrp":{"tr":"' + tr + '","sd":"' + sd
-                    + '","ed":"' + ed + '","g":"' + g + '"},"dmSelc":{"dm":"api","op":[{"name":"'
-                    + api + '","version":"' + apiversion + '","provider":"' + provider + '"}]}}';
+                    + '/dashboards/' + dashboard + '/' + drillDown + '?widgetStates='
+                    + encodeURI(JSON.stringify(queryParams));
             }
         }
     }

--- a/components/org.wso2.analytics.apim.widgets/APIMOverallApiUsage/src/CustomTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMOverallApiUsage/src/CustomTable.jsx
@@ -21,7 +21,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CustomTableToolbar } from '@analytics-apim/common-lib';
 import { FormattedMessage } from 'react-intl';
-import Link from '@material-ui/core/Link';
 import MenuItem from '@material-ui/core/MenuItem';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -133,6 +132,9 @@ const styles = theme => ({
     },
     paginationActions: {
         marginLeft: 0,
+    },
+    tableRow: {
+        cursor: 'pointer',
     },
 });
 
@@ -289,6 +291,8 @@ class CustomTable extends React.Component {
                                         <TableRow
                                             hover
                                             tabIndex={-1}
+                                            className={classes.tableRow}
+                                            onClick={() => onClickTableRow(option)}
                                         >
                                             <TableCell component='th' scope='row'>
                                                 <Checkbox
@@ -298,9 +302,7 @@ class CustomTable extends React.Component {
                                                         option.apiname + ':' + option.apiversion,
                                                     )}
                                                 />
-                                                <Link href='#' onClick={() => onClickTableRow(option)} color='inherit'>
-                                                    {option.apiname}
-                                                </Link>
+                                                {option.apiname}
                                             </TableCell>
                                             <TableCell component='th' scope='row' numeric>
                                                 {option.apiversion}

--- a/components/org.wso2.analytics.apim.widgets/APIMSubscriptionsAnalytics/src/APIMSubscriptionsAnalyticsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMSubscriptionsAnalytics/src/APIMSubscriptionsAnalyticsWidget.jsx
@@ -310,10 +310,15 @@ class APIMSubscriptionsAnalyticsWidget extends Widget {
                 const provider = (apiname.split('(')[1]).split(')')[0].trim();
                 const locationParts = window.location.pathname.split('/');
                 const dashboard = locationParts[locationParts.length - 2];
-
+                const queryParams = {
+                    dmSelc: {
+                        dm: 'api',
+                        op: [{ name: api, version: apiversion, provider }],
+                    },
+                };
                 window.location.href = window.contextPath
-                    + '/dashboards/' + dashboard + '/' + drillDown + '#{"dmSelc":{"dm":"api","op":[{"name":"' + api
-                    + '","version":"' + apiversion + '","provider":"' + provider + '"}]}}';
+                    + '/dashboards/' + dashboard + '/' + drillDown + '?widgetStates='
+                    + encodeURI(JSON.stringify(queryParams));
             }
         }
     }

--- a/components/org.wso2.analytics.apim.widgets/APIMSubscriptionsAnalytics/src/CustomTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMSubscriptionsAnalytics/src/CustomTable.jsx
@@ -21,7 +21,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CustomTableToolbar } from '@analytics-apim/common-lib';
 import { FormattedMessage } from 'react-intl';
-import Link from '@material-ui/core/Link';
 import MenuItem from '@material-ui/core/MenuItem';
 import Moment from 'moment';
 import Table from '@material-ui/core/Table';
@@ -144,6 +143,9 @@ const styles = theme => ({
     title: {
         paddingLeft: 20,
         paddingTop: 15,
+    },
+    tableRow: {
+        cursor: 'pointer',
     },
 });
 
@@ -276,11 +278,11 @@ class CustomTable extends React.Component {
                                         <TableRow
                                             hover
                                             tabIndex={-1}
+                                            onClick={() => onClickTableRow(n)}
+                                            className={classes.tableRow}
                                         >
                                             <TableCell component='th' scope='row'>
-                                                <Link href='#' onClick={() => onClickTableRow(n)} color='inherit'>
-                                                    {n.apiname}
-                                                </Link>
+                                                {n.apiname}
                                             </TableCell>
                                             <TableCell component='th' scope='row' numeric>
                                                 {n.apiversion}

--- a/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/APIMTopFaultyApisWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/APIMTopFaultyApisWidget.jsx
@@ -298,11 +298,21 @@ class APIMTopFaultyApisWidget extends Widget {
                 const provider = (apiname.split('(')[1]).split(')')[0].trim();
                 const locationParts = window.location.pathname.split('/');
                 const dashboard = locationParts[locationParts.length - 2];
-
+                const queryParams = {
+                    dtrp: {
+                        tr,
+                        sd,
+                        ed,
+                        g,
+                    },
+                    dmSelc: {
+                        dm: 'api',
+                        op: [{ name: api, version: apiversion, provider }],
+                    },
+                };
                 window.location.href = window.contextPath
-                    + '/dashboards/' + dashboard + '/' + drillDown + '#{"dtrp":{"tr":"' + tr + '","sd":"' + sd
-                    + '","ed":"' + ed + '","g":"' + g + '"},"dmSelc":{"dm":"api","op":[{"name":"'
-                    + api + '","version":"' + apiversion + '","provider":"' + provider + '"}]}}';
+                    + '/dashboards/' + dashboard + '/' + drillDown + '?widgetStates='
+                    + encodeURI(JSON.stringify(queryParams));
             }
         }
     }

--- a/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/CustomTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopFaultyApis/src/CustomTable.jsx
@@ -21,7 +21,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CustomTableToolbar } from '@analytics-apim/common-lib';
 import { FormattedMessage } from 'react-intl';
-import Link from '@material-ui/core/Link';
 import MenuItem from '@material-ui/core/MenuItem';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -124,6 +123,9 @@ const styles = theme => ({
     },
     paginationActions: {
         marginLeft: 0,
+    },
+    tableRow: {
+        cursor: 'pointer',
     },
 });
 
@@ -248,11 +250,11 @@ class CustomTable extends React.Component {
                                             hover
                                             tabIndex={-1}
                                             key={n.id}
+                                            onClick={() => onClickTableRow(n)}
+                                            className={classes.tableRow}
                                         >
                                             <TableCell component='th' scope='row'>
-                                                <Link href='#' onClick={() => onClickTableRow(n)} color='inherit'>
-                                                    {n.apiname}
-                                                </Link>
+                                                {n.apiname}
                                             </TableCell>
                                             <TableCell component='th' scope='row' numeric>
                                                 {n.apiversion}

--- a/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/APIMTopThrottledApisWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/APIMTopThrottledApisWidget.jsx
@@ -305,11 +305,21 @@ class APIMTopThrottledApisWidget extends Widget {
                 const provider = (apiname.split('(')[1]).split(')')[0].trim();
                 const locationParts = window.location.pathname.split('/');
                 const dashboard = locationParts[locationParts.length - 2];
-
+                const queryParams = {
+                    dtrp: {
+                        tr,
+                        sd,
+                        ed,
+                        g,
+                    },
+                    dmSelc: {
+                        dm: 'api',
+                        op: [{ name: api, version: apiversion, provider }],
+                    },
+                };
                 window.location.href = window.contextPath
-                    + '/dashboards/' + dashboard + '/' + drillDown + '#{"dtrp":{"tr":"' + tr + '","sd":"' + sd
-                    + '","ed":"' + ed + '","g":"' + g + '"},"dmSelc":{"dm":"api","op":[{"name":"'
-                    + api + '","version":"' + apiversion + '","provider":"' + provider + '"}]}}';
+                    + '/dashboards/' + dashboard + '/' + drillDown + '?widgetStates='
+                    + encodeURI(JSON.stringify(queryParams));
             }
         }
     }

--- a/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/CustomTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMTopThrottledOutApis/src/CustomTable.jsx
@@ -21,7 +21,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CustomTableToolbar } from '@analytics-apim/common-lib';
 import { FormattedMessage } from 'react-intl';
-import Link from '@material-ui/core/Link';
 import MenuItem from '@material-ui/core/MenuItem';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -132,6 +131,9 @@ const styles = theme => ({
     },
     paginationActions: {
         marginLeft: 0,
+    },
+    tableRow: {
+        cursor: 'pointer',
     },
 });
 
@@ -257,11 +259,11 @@ class CustomTable extends React.Component {
                                             hover
                                             tabIndex={-1}
                                             key={n.id}
+                                            className={classes.tableRow}
+                                            onClick={() => onClickTableRow(n)}
                                         >
                                             <TableCell component='th' scope='row'>
-                                                <Link href='#' onClick={() => onClickTableRow(n)} color='inherit'>
-                                                    {n.apiname}
-                                                </Link>
+                                                {n.apiname}
                                             </TableCell>
                                             <TableCell component='th' scope='row' numeric>
                                                 {n.apiversion}

--- a/components/org.wso2.analytics.apim.widgets/OverallFaultAnalytics/src/OverallFaultAnalytics.jsx
+++ b/components/org.wso2.analytics.apim.widgets/OverallFaultAnalytics/src/OverallFaultAnalytics.jsx
@@ -67,6 +67,9 @@ export default function OverallFaultAnalytics(props) {
             paddingBottom: '10px',
             marginTop: 0,
         },
+        divClick: {
+            cursor: 'pointer',
+        },
     };
     const chartConfig = {
         x: 'TIME',
@@ -141,7 +144,11 @@ export default function OverallFaultAnalytics(props) {
                                 </Paper>
                             </div>
                         ) : (
-                            <div onClick={handleOnClick} onKeyDown={handleOnClick}>
+                            <div
+                                style={styles.divClick}
+                                onClick={handleOnClick}
+                                onKeyDown={handleOnClick}
+                            >
                                 <VizG
                                     config={chartConfig}
                                     metadata={metadata}

--- a/components/org.wso2.analytics.apim.widgets/OverallFaultAnalytics/src/OverallFaultAnalyticsWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/OverallFaultAnalytics/src/OverallFaultAnalyticsWidget.jsx
@@ -211,9 +211,14 @@ class OverallFaultAnalyticsWidget extends Widget {
             if (drillDown) {
                 const locationParts = window.location.pathname.split('/');
                 const dashboard = locationParts[locationParts.length - 2];
-
+                const queryParams = {
+                    dtrp: {
+                        tr: '1month',
+                    },
+                };
                 window.location.href = window.contextPath
-                    + '/dashboards/' + dashboard + '/' + drillDown + '#{"dtrp":{"tr":"1month"}}';
+                    + '/dashboards/' + dashboard + '/' + drillDown + '?widgetStates='
+                    + encodeURI(JSON.stringify(queryParams));
             }
         }
     }

--- a/components/org.wso2.analytics.apim.widgets/PerformanceSummary/src/PerformanceSummaryWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/PerformanceSummary/src/PerformanceSummaryWidget.jsx
@@ -290,10 +290,18 @@ class PerformanceSummaryWidget extends Widget {
                 const provider = splitName[1].split(' (')[1].split(')')[0].trim();
                 const locationParts = window.location.pathname.split('/');
                 const dashboard = locationParts[locationParts.length - 2];
-
+                const queryParams = {
+                    dtrp: {
+                        tr: '1month',
+                    },
+                    dmSelc: {
+                        dm: 'api',
+                        op: [{ name: api, version: apiversion, provider }],
+                    },
+                };
                 window.location.href = window.contextPath
-                    + '/dashboards/' + dashboard + '/' + drillDown + '#{"dtrp":{"tr":"1month"},"dmSelc":{"dm":"api",'
-                    + '"op":[{"name":"' + api + '","version":"' + apiversion + '","provider":"' + provider + '"}]}}';
+                    + '/dashboards/' + dashboard + '/' + drillDown + '?widgetStates='
+                    + encodeURI(JSON.stringify(queryParams));
             }
         }
     }

--- a/components/org.wso2.analytics.apim.widgets/ThrottleSummary/src/ThrottleSummaryWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/ThrottleSummary/src/ThrottleSummaryWidget.jsx
@@ -297,10 +297,18 @@ class ThrottleSummaryWidget extends Widget {
                 const provider = splitName[1].split(' (')[1].split(')')[0].trim();
                 const locationParts = window.location.pathname.split('/');
                 const dashboard = locationParts[locationParts.length - 2];
-
+                const queryParams = {
+                    dtrp: {
+                        tr: '1month',
+                    },
+                    dmSelc: {
+                        dm: 'api',
+                        op: [{ name: api, version: apiversion, provider }],
+                    },
+                };
                 window.location.href = window.contextPath
-                    + '/dashboards/' + dashboard + '/' + drillDown + '#{"dtrp":{"tr":"1month"},"dmSelc":{"dm":"api",'
-                    + '"op":[{"name":"' + api + '","version":"' + apiversion + '","provider":"' + provider + '"}]}}';
+                    + '/dashboards/' + dashboard + '/' + drillDown + '?widgetStates='
+                    + encodeURI(JSON.stringify(queryParams));
             }
         }
     }

--- a/components/org.wso2.analytics.apim.widgets/Top10ApiPerformanceOverTime/src/Top10ApiPerformanceOverTime.jsx
+++ b/components/org.wso2.analytics.apim.widgets/Top10ApiPerformanceOverTime/src/Top10ApiPerformanceOverTime.jsx
@@ -67,6 +67,9 @@ export default function Top10ApiPerformanceOverTime(props) {
             paddingBottom: '10px',
             marginTop: 0,
         },
+        divClick: {
+            cursor: 'pointer',
+        },
     };
     const chartConfig = {
         x: 'TIME',
@@ -147,7 +150,11 @@ export default function Top10ApiPerformanceOverTime(props) {
                                     </Paper>
                                 </div>
                             ) : (
-                                <div onClick={() => handleOnClick()} onKeyDown={() => handleOnClick()}>
+                                <div
+                                    style={styles.divClick}
+                                    onClick={() => handleOnClick()}
+                                    onKeyDown={() => handleOnClick()}
+                                >
                                     <VizG
                                         config={chartConfig}
                                         metadata={metadata}

--- a/components/org.wso2.analytics.apim.widgets/Top10ApiPerformanceOverTime/src/Top10ApiPerformanceOverTimeWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/Top10ApiPerformanceOverTime/src/Top10ApiPerformanceOverTimeWidget.jsx
@@ -287,17 +287,20 @@ class Top10ApiPerformanceOverTimeWidget extends Widget {
             const { drillDown } = configs.options;
 
             if (drillDown) {
-                let apiList = selectedOptions.map((opt) => {
-                    return '{"name":"' + opt.name + '","version":"' + opt.version + '","provider":"'
-                        + opt.provider + '"}';
-                });
-                apiList = apiList.join(',');
                 const locationParts = window.location.pathname.split('/');
                 const dashboard = locationParts[locationParts.length - 2];
-
+                const queryParams = {
+                    dtrp: {
+                        tr: '1month',
+                    },
+                    dmSelc: {
+                        dm: 'api',
+                        op: selectedOptions,
+                    },
+                };
                 window.location.href = window.contextPath
-                    + '/dashboards/' + dashboard + '/' + drillDown + '#{"dtrp":{"tr":"1month"},"dmSelc":{"dm":"api",'
-                    + '"op":[' + apiList + ']}}';
+                    + '/dashboards/' + dashboard + '/' + drillDown + '?widgetStates='
+                    + encodeURI(JSON.stringify(queryParams));
             }
         }
     }

--- a/components/org.wso2.analytics.apim.widgets/Top10ApiUsageOverTime/src/Top10ApiUsageOverTime.jsx
+++ b/components/org.wso2.analytics.apim.widgets/Top10ApiUsageOverTime/src/Top10ApiUsageOverTime.jsx
@@ -71,6 +71,9 @@ export default function Top10ApiUsageOverTime(props) {
             paddingBottom: '10px',
             marginTop: 0,
         },
+        divClick: {
+            cursor: 'pointer',
+        },
     };
     const chartConfig = {
         x: 'TIME',
@@ -149,6 +152,7 @@ export default function Top10ApiUsageOverTime(props) {
                                 </div>
                             ) : (
                                 <div
+                                    style={styles.divClick}
                                     onClick={() => handleOnClick()}
                                     onKeyDown={() => handleOnClick()}
                                 >

--- a/components/org.wso2.analytics.apim.widgets/Top10ApiUsageOverTime/src/Top10ApiUsageOverTimeWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/Top10ApiUsageOverTime/src/Top10ApiUsageOverTimeWidget.jsx
@@ -289,17 +289,20 @@ class Top10ApiUsageOverTimeWidget extends Widget {
             const { drillDown } = configs.options;
 
             if (drillDown) {
-                let apiList = selectedOptions.map((opt) => {
-                    return '{"name":"' + opt.name + '","version":"' + opt.version + '","provider":"'
-                        + opt.provider + '"}';
-                });
-                apiList = apiList.join(',');
                 const locationParts = window.location.pathname.split('/');
                 const dashboard = locationParts[locationParts.length - 2];
-
+                const queryParams = {
+                    dtrp: {
+                        tr: '1month',
+                    },
+                    dmSelc: {
+                        dm: 'api',
+                        op: selectedOptions,
+                    },
+                };
                 window.location.href = window.contextPath
-                    + '/dashboards/' + dashboard + '/' + drillDown + '#{"dtrp":{"tr":"1month"},"dmSelc":{"dm":"api",'
-                    + '"op":[' + apiList + ']}}';
+                    + '/dashboards/' + dashboard + '/' + drillDown + '?widgetStates='
+                    + encodeURI(JSON.stringify(queryParams));
             }
         }
     }

--- a/components/org.wso2.analytics.apim.widgets/Top10ThrottledApisOverTime/src/Top10ThrottledApisOverTime.jsx
+++ b/components/org.wso2.analytics.apim.widgets/Top10ThrottledApisOverTime/src/Top10ThrottledApisOverTime.jsx
@@ -67,6 +67,9 @@ export default function Top10ThrottledApisOverTime(props) {
             paddingBottom: '10px',
             marginTop: 0,
         },
+        divClick: {
+            cursor: 'pointer',
+        },
     };
     const chartConfig = {
         x: 'TIME',
@@ -145,7 +148,11 @@ export default function Top10ThrottledApisOverTime(props) {
                                 </Paper>
                             </div>
                         ) : (
-                            <div onClick={() => handleOnClick()} onKeyDown={() => handleOnClick()}>
+                            <div
+                                style={styles.divClick}
+                                onClick={() => handleOnClick()}
+                                onKeyDown={() => handleOnClick()}
+                            >
                                 <VizG
                                     config={chartConfig}
                                     metadata={metadata}

--- a/components/org.wso2.analytics.apim.widgets/Top10ThrottledApisOverTime/src/Top10ThrottledApisOverTimeWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/Top10ThrottledApisOverTime/src/Top10ThrottledApisOverTimeWidget.jsx
@@ -286,17 +286,20 @@ class Top10ThrottledApisOverTimeWidget extends Widget {
             const { drillDown } = configs.options;
 
             if (drillDown) {
-                let apiList = selectedOptions.map((opt) => {
-                    return '{"name":"' + opt.name + '","version":"' + opt.version + '","provider":"'
-                        + opt.provider + '"}';
-                });
-                apiList = apiList.join(',');
                 const locationParts = window.location.pathname.split('/');
                 const dashboard = locationParts[locationParts.length - 2];
-
+                const queryParams = {
+                    dtrp: {
+                        tr: '1month',
+                    },
+                    dmSelc: {
+                        dm: 'api',
+                        op: selectedOptions,
+                    },
+                };
                 window.location.href = window.contextPath
-                    + '/dashboards/' + dashboard + '/' + drillDown + '#{"dtrp":{"tr":"1month"},"dmSelc":{"dm":"api",'
-                    + '"op":[' + apiList + ']}}';
+                    + '/dashboards/' + dashboard + '/' + drillDown + '?widgetStates='
+                    + encodeURI(JSON.stringify(queryParams));
             }
         }
     }


### PR DESCRIPTION
## Purpose
Fix analytics dashboard drill downs to use query params instead of hash.

Fixes: https://github.com/wso2/analytics-apim/issues/1226 , https://github.com/wso2/analytics-apim/issues/1217
