### PR TITLE
Limit the primary key length so that it does not exceed DB2 PK limit

### DIFF
--- a/features/org.wso2.analytics.apim.feature/src/main/resources/siddhi-files/APIM_ERROR_SUMMARY.siddhi
+++ b/features/org.wso2.analytics.apim.feature/src/main/resources/siddhi-files/APIM_ERROR_SUMMARY.siddhi
@@ -38,7 +38,7 @@ _2xx int, _4xx int, _5xx int, responseCount int, faultCount int, throttledCount 
 
 
 -- API details summary(Error details, traffic details)
-@store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB',field.length = "apiMethod:40")
+@store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB',field.length = "apiMethod:40, applicationId:40")
 @purge(enable='true', interval='60 min', @retentionPeriod(sec='5 minutes', min='72 hours', hours='90 days', days='1 year', months='10 years'))
 define aggregation ApiErrorAnalysisAgg
 from ErrorSummaryStream


### PR DESCRIPTION
## Purpose
This PR fixes the issue https://github.com/wso2/analytics-apim/issues/1342 by limiting the primary key length so that it does not exceed the DB2 PK limit.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes