### PR TITLE
Fixes the incorrect x-axis name for API USAGE SUMMARY widget.

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/APITrafficSummary/src/ResourceViewErrorTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APITrafficSummary/src/ResourceViewErrorTable.jsx
@@ -85,7 +85,7 @@ class APIViewErrorTable extends React.Component {
     }
 
     getPieChartForAPI(data) {
-        const { handleOnClick } = this.props;
+        const { handleOnClick, drillDownType } = this.props;
         const {
             successSelected, faultySelected, throttledSelected,
         } = this.state;
@@ -101,6 +101,12 @@ class APIViewErrorTable extends React.Component {
             }
             return label;
         };
+        let label = 'api';
+        if (drillDownType === 'version') {
+            label = 'API Version';
+        } else if (drillDownType === 'resource') {
+            label = 'API Operation';
+        }
 
         return (
             <div>
@@ -115,7 +121,7 @@ class APIViewErrorTable extends React.Component {
                     }}
                 >
                     <VictoryAxis
-                        label={() => 'API Operation'.toUpperCase()}
+                        label={label.toUpperCase()}
                         tickCount={10}
                         tickLabelComponent={<VictoryLabel angle={45} />}
                         style={{


### PR DESCRIPTION
## Purpose
Fixes the incorrect x-axis name for API USAGE SUMMARY widget.
Fixes https://github.com/wso2/analytics-apim/issues/1421

## Automation tests
 - Integration tests
Tested the rendering with a locally build pack

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Chrome 81.0.4044.138