### PR TITLE
Adds x-axis tick labels for API LATENCY SUMMARY widget.

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/APILatencySummary/src/ResourceViewErrorTable.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APILatencySummary/src/ResourceViewErrorTable.jsx
@@ -105,7 +105,7 @@ class APIViewErrorTable extends React.Component {
                     responsive={false}
                     domainPadding={{ x: [20, 20] }}
                     padding={{
-                        top: 50, bottom: 50, right: 50, left: 50,
+                        top: 50, bottom: 120, right: 50, left: 50,
                     }}
                     theme={VictoryTheme.material}
                     height={400}
@@ -113,13 +113,14 @@ class APIViewErrorTable extends React.Component {
                 >
                     <VictoryAxis
                         label={() => 'API Operation'.toUpperCase()}
-                        tickLabelComponent={<VictoryLabel angle={45} text='' />}
+                        tickCount={10}
+                        tickLabelComponent={<VictoryLabel angle={45} />}
                         style={{
                             axis: { stroke: '#756f6a' },
                             axisLabel: { fontSize: 15, padding: 30 },
                             grid: { stroke: () => 0 },
                             ticks: { stroke: 'grey', size: 5 },
-                            tickLabels: { fontSize: 9, padding: 5 },
+                            tickLabels: { fontSize: 9, textAnchor: 'start' },
                         }}
                     />
                     <VictoryAxis


### PR DESCRIPTION
## Purpose
Adds x-axis tick labels for API LATENCY SUMMARY widget.
Fixes https://github.com/wso2/analytics-apim/issues/1422

Following image shows the labels
![issue_tick_labels](https://user-images.githubusercontent.com/25489203/89383222-bdff4980-d719-11ea-9285-59c7dfaa612d.png)


## Automation tests
 - Integration tests
Tested the rendering with a locally build pack

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Chrome 81.0.4044.138