### PR TITLE
Fix time range propagation when drill down

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/PerformanceSummary/src/PerformanceSummaryWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/PerformanceSummary/src/PerformanceSummaryWidget.jsx
@@ -283,6 +283,9 @@ class PerformanceSummaryWidget extends Widget {
             const { drillDown } = configs.options;
 
             if (drillDown) {
+                const {
+                    tr, sd, ed, g,
+                } = super.getGlobalState('dtrp');
                 const name = Object.keys(data).find(key => key.includes('::'));
                 const splitName = name.split(' :: ');
                 const api = splitName[0].trim();
@@ -292,7 +295,10 @@ class PerformanceSummaryWidget extends Widget {
                 const dashboard = locationParts[locationParts.length - 2];
                 const queryParams = {
                     dtrp: {
-                        tr: '1month',
+                        tr,
+                        sd,
+                        ed,
+                        g,
                     },
                     dmSelc: {
                         dm: 'api',

--- a/components/org.wso2.analytics.apim.widgets/ThrottleSummary/src/ThrottleSummaryWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/ThrottleSummary/src/ThrottleSummaryWidget.jsx
@@ -290,6 +290,9 @@ class ThrottleSummaryWidget extends Widget {
             const { drillDown } = configs.options;
 
             if (drillDown) {
+                const {
+                    tr, sd, ed, g,
+                } = super.getGlobalState('dtrp');
                 const name = Object.keys(data).find(key => key.includes('::'));
                 const splitName = name.split(' :: ');
                 const api = splitName[0].trim();
@@ -299,7 +302,10 @@ class ThrottleSummaryWidget extends Widget {
                 const dashboard = locationParts[locationParts.length - 2];
                 const queryParams = {
                     dtrp: {
-                        tr: '1month',
+                        tr,
+                        sd,
+                        ed,
+                        g,
                     },
                     dmSelc: {
                         dm: 'api',


### PR DESCRIPTION
## Purpose
When drilling down from performance summary and throttle summary pages, the data selection does not get propagated to the landing page. This PR fixes it.