### PR TITLE
Fix API version usage summary widget title styling

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/APIMApiVersionUsageSummary/src/resources/widgetConf.json
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiVersionUsageSummary/src/resources/widgetConf.json
@@ -1,5 +1,5 @@
 {
-  "name": "APIM API VERSION Usage Summary",
+  "name": "APIM API VERSION USAGE SUMMARY",
   "id": "APIMApiVersionUsageSummary",
   "thumbnailURL": "",
   "configs": {


### PR DESCRIPTION
## Purpose
The  API version usage summary widget title has inconsistent styling with a combination of upper and lower case letters. This PR makes the title upper case.

Fixes https://github.com/wso2/analytics-apim/issues/1449