### PR TITLE
Allow service provider creation when the password grant is disabled

### DIFF
--- a/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClient.java
+++ b/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClient.java
@@ -631,8 +631,7 @@ public class ApimIdPClient extends ExternalIdPClient {
             customUrlInfo) throws IdPClientException {
 
         String grantType =
-                IdPClientConstants.PASSWORD_GRANT_TYPE + SPACE + IdPClientConstants.AUTHORIZATION_CODE_GRANT_TYPE +
-                        SPACE + IdPClientConstants.REFRESH_GRANT_TYPE;
+                IdPClientConstants.AUTHORIZATION_CODE_GRANT_TYPE + SPACE + IdPClientConstants.REFRESH_GRANT_TYPE;
         String callBackUrl;
         String postLogoutRedirectUrl = this.baseUrl + FORWARD_SLASH + appContext;
         boolean isCustomUrlApplicable = clientName.equals(ApimIdPClientConstants.PORTAL_APP_NAME) &&


### PR DESCRIPTION
## Purpose
Fixes issue: wso2/analytics-apim#1470

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes