### PR TITLE
Move debug log to avoid null pointer when the customUrlInfo.isEnabled() false

### DIFF
--- a/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClient.java
+++ b/components/org.wso2.analytics.apim.idp.client/src/main/java/org/wso2/analytics/apim/idp/client/ApimIdPClient.java
@@ -733,9 +733,9 @@ public class ApimIdPClient extends ExternalIdPClient {
                     CustomUrlInfoDevPortalDTO customUrlInfoDevPortalDTO = customUrlInfo.getDevPortalUrlDTO();
                     String customUrl = "https://" + customUrlInfoDevPortalDTO.getUrl();
                     customUrlInfoDevPortalDTO.setUrl(customUrl);
-                }
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(customUrlInfo.toString());
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(customUrlInfo.toString());
+                    }
                 }
             } catch (IOException e) {
                 throw new IdPClientException("Error occurred while parsing the Custom Url info response for tenant :"


### PR DESCRIPTION
## Purpose
Fixes issue #1495

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes