### PR TITLE
Fix apilatancy widget when underscore present in path

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/APIMApiLatencyTime/src/APIMApiLatency.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiLatencyTime/src/APIMApiLatency.jsx
@@ -213,7 +213,7 @@ export default function APIMApiLatency(props) {
                                                 // disabled={operationList && operationList.length === 0}
                                                 placeholder='Select Operation'
                                                 getLabel={item => item.URL_PATTERN + ' ( ' + item.HTTP_METHOD + ' )'}
-                                                getValue={item => item.URL_PATTERN + '_' + item.HTTP_METHOD}
+                                                getValue={item => item.URL_PATTERN + ' ' + item.HTTP_METHOD}
                                             />
                                         </div>
                                     </FormControl>

--- a/components/org.wso2.analytics.apim.widgets/APIMApiLatencyTime/src/APIMApiLatencyWidget.jsx
+++ b/components/org.wso2.analytics.apim.widgets/APIMApiLatencyTime/src/APIMApiLatencyWidget.jsx
@@ -348,8 +348,8 @@ class APIMApiLatencyWidget extends Widget {
                 return obj;
             })
             .sort((a, b) => {
-                const tempa = (a.URL_PATTERN + '_' + a.HTTP_METHOD).toLowerCase();
-                const tempb = (b.URL_PATTERN + '_' + b.HTTP_METHOD).toLowerCase();
+                const tempa = (a.URL_PATTERN + ' ' + a.HTTP_METHOD).toLowerCase();
+                const tempb = (b.URL_PATTERN + ' ' + b.HTTP_METHOD).toLowerCase();
 
                 if (tempb > tempa) {
                     return -1;
@@ -366,10 +366,10 @@ class APIMApiLatencyWidget extends Widget {
             let filterSelectedOperations;
             if (Array.isArray(operationSelected)) {
                 filterSelectedOperations = operationSelected
-                    .filter(op => resourceList.find(item => item.URL_PATTERN + '_' + item.HTTP_METHOD === op));
+                    .filter(op => resourceList.find(item => item.URL_PATTERN + ' ' + item.HTTP_METHOD === op));
             } else {
                 const selectedItem = resourceList
-                    .find(item => item.URL_PATTERN + '_' + item.HTTP_METHOD === operationSelected);
+                    .find(item => item.URL_PATTERN + ' ' + item.HTTP_METHOD === operationSelected);
                 if (selectedItem) {
                     filterSelectedOperations = operationSelected;
                 } else {
@@ -383,7 +383,7 @@ class APIMApiLatencyWidget extends Widget {
                 if (isGraphQL) {
                     filterSelectedOperations = [];
                 } else if (resourceList.length > 0) {
-                    filterSelectedOperations = resourceList[0].URL_PATTERN + '_' + resourceList[0].HTTP_METHOD;
+                    filterSelectedOperations = resourceList[0].URL_PATTERN + ' ' + resourceList[0].HTTP_METHOD;
                 } else {
                     filterSelectedOperations = [];
                 }
@@ -415,10 +415,10 @@ class APIMApiLatencyWidget extends Widget {
                 if (Array.isArray(operationSelected)) {
                     if (operationSelected.length > 0) {
                         const opsString = operationSelected
-                            .map(item => item.split('_')[0])
+                            .map(item => item.split(' ')[0])
                             .sort()
                             .join(',');
-                        const firstOp = operationSelected[0].split('_')[1];
+                        const firstOp = operationSelected[0].split(' ')[1];
                         resources = 'apiResourceTemplate==\'' + opsString + '\' AND apiMethod==\''
                             + firstOp + '\'';
                     } else {
@@ -426,7 +426,7 @@ class APIMApiLatencyWidget extends Widget {
                         return;
                     }
                 } else if (operationSelected !== -1) {
-                    const operation = operationSelected.split('_');
+                    const operation = operationSelected.split(' ');
                     resources = 'apiResourceTemplate==\'' + operation[0] + '\' AND apiMethod==\'' + operation[1] + '\'';
                 } else {
                     this.setState({ inProgress: false, latencyData: [] });


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-apim/issues/10639

This PR fixes the issue where the API LATENCY TIME widget in the API Performance tab does not display data for scenarios similar to the following (when there is an underscore present in the path).

GET user/a_user --> for path --> user/{username} 
GET user/a_user --> for path --> user/a_user  
GET pet/1 --> for path --> pet/{pet_id}  