### PR TITLE
Bump @wso2-dashboards/widget to 1.5.1

### DIFF
--- a/components/org.wso2.analytics.apim.widgets/APILatencyOverTime/package.json
+++ b/components/org.wso2.analytics.apim.widgets/APILatencyOverTime/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^3.9.0",
     "@material-ui/icons": "^3.0.2",
-    "@wso2-dashboards/widget": "^1.4.0",
+    "@wso2-dashboards/widget": "^1.5.1",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-intl": "^2.8.0",

--- a/components/org.wso2.analytics.apim.widgets/APILatencySummary/package.json
+++ b/components/org.wso2.analytics.apim.widgets/APILatencySummary/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^3.9.0",
     "@material-ui/icons": "^3.0.2",
-    "@wso2-dashboards/widget": "^1.4.0",
+    "@wso2-dashboards/widget": "^1.5.1",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-intl": "^2.8.0",

--- a/components/org.wso2.analytics.apim.widgets/APITrafficOverTime/package.json
+++ b/components/org.wso2.analytics.apim.widgets/APITrafficOverTime/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^3.9.0",
     "@material-ui/icons": "^3.0.2",
-    "@wso2-dashboards/widget": "^1.4.0",
+    "@wso2-dashboards/widget": "^1.5.1",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-intl": "^2.8.0",

--- a/components/org.wso2.analytics.apim.widgets/APITrafficSummary/package.json
+++ b/components/org.wso2.analytics.apim.widgets/APITrafficSummary/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^3.9.0",
     "@material-ui/icons": "^3.0.2",
-    "@wso2-dashboards/widget": "^1.4.0",
+    "@wso2-dashboards/widget": "^1.5.1",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-intl": "^2.8.0",

--- a/components/org.wso2.analytics.apim.widgets/AppAndAPIErrorTable/package.json
+++ b/components/org.wso2.analytics.apim.widgets/AppAndAPIErrorTable/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^3.9.0",
     "@material-ui/icons": "^3.0.2",
-    "@wso2-dashboards/widget": "^1.4.0",
+    "@wso2-dashboards/widget": "^1.5.1",
     "@analytics-apim/common-lib": "^1.0.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",

--- a/components/org.wso2.analytics.apim.widgets/AppAndAPIErrorsByTime/package.json
+++ b/components/org.wso2.analytics.apim.widgets/AppAndAPIErrorsByTime/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^3.9.0",
     "@material-ui/icons": "^3.0.2",
-    "@wso2-dashboards/widget": "^1.4.0",
+    "@wso2-dashboards/widget": "^1.5.1",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-intl": "^2.8.0",

--- a/components/org.wso2.analytics.apim.widgets/ErrorByAppAndAPI/package.json
+++ b/components/org.wso2.analytics.apim.widgets/ErrorByAppAndAPI/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^3.9.0",
     "@material-ui/icons": "^3.0.2",
-    "@wso2-dashboards/widget": "^1.4.0",
+    "@wso2-dashboards/widget": "^1.5.1",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-intl": "^2.8.0",

--- a/components/org.wso2.analytics.apim.widgets/package.json
+++ b/components/org.wso2.analytics.apim.widgets/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@material-ui/core": "^3.9.0",
     "@material-ui/icons": "^3.0.2",
-    "@wso2-dashboards/widget": "^1.5.0",
+    "@wso2-dashboards/widget": "^1.5.1",
     "axios": "^0.16.2",
     "lodash": "^4.17.11",
     "react": "^16.7.0",


### PR DESCRIPTION
## Purpose
Bump the base widget version to 1.5.1 which contains the fix for the widget configuration loading timeout issue.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes