### PR TITLE
Add purging trigger for `ApiLastAccessSummary` in `apim_analytics_data_purging_app` business rule template

### DIFF
--- a/features/org.wso2.analytics.apim.feature/src/main/resources/templates/wso2-apim-analytics.json
+++ b/features/org.wso2.analytics.apim.feature/src/main/resources/templates/wso2-apim-analytics.json
@@ -261,14 +261,24 @@
             "templates": [
                {
                   "type": "siddhiApp",
-                  "content": "@App:name(\"apim_analytics_data_purging_app_0\")\n@App:description(\"App purges data of Raw tables in APIM Analytics\")\n\ndefine trigger DataPurgingTrigger at every ${triggerTime};\n\n-- Table Used in Unusual IP Access Alert\n@PrimaryKey('applicationConsumerKey','ip')\n@store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')\ndefine table ApimIPAccessSummary (username string, applicationConsumerKey string, ip string, lastAccessedDate long) ;\n\n-- Table Used in Unusual IP Access Alert\n@PrimaryKey('applicationConsumerKey','username')\n@store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')\ndefine table ApimIPAccessAlertCount (username string, applicationConsumerKey string, requestCount long) ;\n\n-- Delete all Data from ApimIPAccessSummary when the trigger is triggered\nfrom DataPurgingTrigger\ndelete ApimIPAccessSummary on \"1\" == \"1\";\n\n-- Delete all Data from ApimIPAccessAlertCount when the trigger is triggered\nfrom DataPurgingTrigger\ndelete ApimIPAccessAlertCount on \"1\" == \"1\";"
+                  "content": "@App:name(\"apim_analytics_data_purging_app_0\") \n@App:description(\"App purges data of Raw tables in APIM Analytics\")\n\ndefine trigger IPAccessAlertCountPurgingTrigger at every ${accessRequestCountDeletionTriggerInterval};\n\n-- Runs at 12 AM every day\ndefine trigger IPAccessSummaryPurgingTrigger at '0 0 0 1/1 * ? *' ;\n\n-- Table Used in Unusual IP Access Alert\n@PrimaryKey('applicationConsumerKey','ip')\n@index('lastAccessedDate')\n@store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')\ndefine table ApimIPAccessSummary (username string, applicationConsumerKey string, ip string, lastAccessedDate long) ;\n\n-- Table Used in Unusual IP Access Alert\n@PrimaryKey('applicationConsumerKey','username')\n@store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')\ndefine table ApimIPAccessAlertCount (username string, applicationConsumerKey string, requestCount long) ;\n\n-- Derive the purging end timestamp based on the given retention period\nfrom IPAccessSummaryPurgingTrigger\nselect time:timestampInMilliseconds(time:dateSub(time:currentTimestamp(), ${accessSummaryPurgingRetentionPeriodAmount}, '${accessSummaryPurgingRetentionPeriodUnit}', 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss') as purgingEndTimestamp\ninsert into IPAccessSummaryPurgingStream;\n\n-- Delete data that is older than the retention period, when the IPAccessAlertCountPurgingTrigger is triggered\nfrom IPAccessSummaryPurgingStream\ndelete ApimIPAccessSummary on ApimIPAccessSummary.lastAccessedDate < purgingEndTimestamp;\n\n-- Delete all Data from ApimIPAccessAlertCount, when the IPAccessAlertCountPurgingTrigger is triggered\nfrom IPAccessAlertCountPurgingTrigger\ndelete ApimIPAccessAlertCount on \"1\" == \"1\";"
                }
             ],
             "properties": {
-               "triggerTime": {
-                  "fieldName": "Time Interval For Trigger",
-                  "description": "Time Interval to trigger Data purging",
+               "accessRequestCountDeletionTriggerInterval": {
+                  "fieldName": "Time Interval for IP Access Request Count Data Deletion",
+                  "description": "All the existing APIM IP Access request count data, will be deleted per this interval",
                   "defaultValue": "1 years"
+               },
+               "accessSummaryPurgingRetentionPeriodAmount": {
+                  "fieldName": "Last IP Access Retention Period Amount",
+                  "description": "APIM IP Access Summary Data older than this much of the given unit, will be deleted everyday at 00:00",
+                  "defaultValue": "1"
+               },
+               "accessSummaryPurgingRetentionPeriodUnit": {
+                  "fieldName": "Last IP Access Retention Period Unit",
+                  "description": "APIM IP Access Summary Data older than the given amount - measured in this unit, will be deleted everyday at 00:00",
+                  "defaultValue": "years"
                }
             }
          }


### PR DESCRIPTION
## Purpose
$subject. Resolves https://github.com/wso2/api-manager/issues/1276

### New Siddhi App Template for `apim_analytics_data_purging_app_0`
The new Siddhi app template looks like this:
```
@App:name("apim_analytics_data_purging_app_0") 
@App:description("App purges data of Raw tables in APIM Analytics")

define trigger IPAccessAlertCountPurgingTrigger at every ${accessRequestCountDeletionTriggerInterval};
/* eg:
define trigger IPAccessAlertCountPurgingTrigger at every 1 year;
*/

-- Runs at 12 AM every day
define trigger IPAccessSummaryPurgingTrigger at '0 0 0 1/1 * ? *' ;

-- Table Used in Unusual IP Access Alert
@PrimaryKey('applicationConsumerKey','ip')
@index('lastAccessedDate')
@store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
define table ApimIPAccessSummary (username string, applicationConsumerKey string, ip string, lastAccessedDate long) ;

-- Table Used in Unusual IP Access Alert
@PrimaryKey('applicationConsumerKey','username')
@store(type = 'rdbms', datasource = 'APIM_ANALYTICS_DB')
define table ApimIPAccessAlertCount (username string, applicationConsumerKey string, requestCount long) ;

-- Derive the purging end timestamp based on the given retention period
from IPAccessSummaryPurgingTrigger
select time:timestampInMilliseconds(time:dateSub(time:currentTimestamp(), ${accessSummaryPurgingRetentionPeriodAmount}, '${accessSummaryPurgingRetentionPeriodUnit}', 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss') as purgingEndTimestamp -- See below example comment
insert into IPAccessSummaryPurgingStream;

/* eg:
select time:timestampInMilliseconds(time:dateSub(time:currentTimestamp(), 1, 'month', 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss') as purgingEndTimestamp
*/

-- Delete data that is older than the retention period, when the IPAccessAlertCountPurgingTrigger is triggered
from IPAccessSummaryPurgingStream
delete ApimIPAccessSummary on ApimIPAccessSummary.lastAccessedDate < purgingEndTimestamp;

-- Delete all Data from ApimIPAccessAlertCount, when the IPAccessAlertCountPurgingTrigger is triggered
from IPAccessAlertCountPurgingTrigger
delete ApimIPAccessAlertCount on TRUE;
```

* The old `DataPurgingTrigger` trigger has been renamed as `IPAccessAlertCountPurgingTrigger`, since it just deletes the `ApimIPAccessAlertCount` table now. The old `triggerTime`(**Time Interval For Trigger**) property has been renamed as `accessRequestCountDeletionTriggerInterval`(**Time Interval for IP Access Request Count Data Deletion**) to accommodate this convention and be meaningful.
* A new trigger called `IPAccessSummaryPurgingTrigger` has been introduced. This is a cron job which runs at 00:00 every day. Upon invocation, this will:
   * Get the timestamp that is 1 month earlier than the current timestamp
   * Delete records from the `ApimIPAccessSummary` table, of which - `lastAccessedDate` is earlier than the timestamp got above.

#### New Properties
Overall, following configurable properties are now there in the business rule tempate:
```json
            "properties": {
               "accessRequestCountDeletionTriggerInterval": {
                  "fieldName": "Time Interval for IP Access Request Count Data Deletion",
                  "description": "All the existing APIM IP Access request count data, will be deleted per this interval",
                  "defaultValue": "1 years"
               },
               "accessSummaryPurgingRetentionPeriodAmount": {
                  "fieldName": "Last IP Access Retention Period Amount",
                  "description": "APIM IP Access Summary Data older than this much of the given unit, will be deleted everyday at 00:00",
                  "defaultValue": "1"
               },
               "accessSummaryPurgingRetentionPeriodUnit": {
                  "fieldName": "Last IP Access Retention Period Unit",
                  "description": "APIM IP Access Summary Data older than the given amount - measured in this unit, will be deleted everyday at 00:00",
                  "defaultValue": "years"
               }
            }
```